### PR TITLE
refactor(skills): drop unused symlinkSkillModules

### DIFF
--- a/src/helpers/skill_manager.js
+++ b/src/helpers/skill_manager.js
@@ -397,45 +397,6 @@ function processSkill(skill, source, seenSkills) {
 }
 
 /**
- * Symlink skill script modules into the shared scripts/skills/ directory.
- * Third-party skills need their Python modules accessible from the shared
- * scripts directory for imports like `python3 -m skills.{name}.{module}`.
- */
-function symlinkSkillModules(sources) {
-	const scriptsLink = path.join(CLAUDE_SKILLS_DIR, "scripts");
-	if (!pathExists(scriptsLink)) return;
-
-	let scriptsDir;
-	try {
-		scriptsDir = fs.realpathSync(scriptsLink);
-	} catch {
-		return;
-	}
-
-	const skillsPackageDir = path.join(scriptsDir, "skills");
-	if (!fs.existsSync(skillsPackageDir)) return;
-
-	for (const source of sources) {
-		const skills = listSkills(source.cachePath);
-		for (const skill of skills) {
-			const skillScriptsDir = path.join(skill.path, "scripts");
-			if (!fs.existsSync(skillScriptsDir)) continue;
-
-			const moduleName = skill.name.replace(/-/g, "_");
-			const destPath = path.join(skillsPackageDir, moduleName);
-			if (pathExists(destPath)) continue;
-
-			try {
-				fs.symlinkSync(skillScriptsDir, destPath);
-				log.info(`Linked ${skill.name} module → scripts/skills/${moduleName}`);
-			} catch (error) {
-				log.warning(`Failed to link ${skill.name} module: ${error.message}`);
-			}
-		}
-	}
-}
-
-/**
  * Symlink a shared resource (directory or file) if not already linked.
  * Returns true if symlink was created, false if source doesn't exist.
  */
@@ -493,7 +454,6 @@ export function mergeSkills(sources) {
 		}
 	}
 
-	symlinkSkillModules(sources);
 	log.success(`Merged ${seenSkills.size} skills to ${CLAUDE_SKILLS_DIR}`);
 }
 


### PR DESCRIPTION
## Summary

Drops the `symlinkSkillModules` function in `src/helpers/skill_manager.js` and its call site in `mergeSkills`. The function was designed for skills that used `python3 -m skills.{name}.{module}` imports and needed their Python source linked into a shared `scripts/skills/{name}/` package directory.

After axatbhardwaj/claude-skills#1 landed, the only configured skill source (`claude-skills`'s `testing` skill) switched to direct script-path invocation (`python3 <skill-dir>/scripts/testing.py --step 1`). With no consumer of the module-link mechanism, `symlinkSkillModules` early-returns on every run today (`~/.claude/skills/scripts` is not a symlink under the current `mergeSkills` strategy), so this is pure dead-code removal — no behaviour change.

## Validation

- `bun test` — 77/77 pass (same as baseline on `stable`)
- `bun test tests/skill_manager.test.js` — 2/2 pass
- `bun run lint` — clean
- `bun haoshoku.js --skills-update` — still merges 1 skill + 5 agents, identical end-to-end output

## Notes

If a future skill source needs `python3 -m skills.{name}.{module}` imports again, the mechanism can be reintroduced — but it would need `mergeSkills` to also symlink the source repo's `skills/scripts/` directory, which is the missing prerequisite today. Reviving the function in isolation wouldn't help.