### PR TITLE
fix: harden v5.3 config sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Stored unified diffs need leading spaces on blank context lines.
+*.patch -whitespace

--- a/common/flatpacks_arch.txt
+++ b/common/flatpacks_arch.txt
@@ -1,5 +1,4 @@
 io.ente.auth
-io.github.brunofin.Cohesion
 io.github.nozwock.Packet
 com.rtosta.zapzap
 org.gnome.Calendar

--- a/common/paru_applist.txt
+++ b/common/paru_applist.txt
@@ -14,6 +14,7 @@ bitwarden
 partitionmanager
 inotify-tools
 thunar
+swayimg
 teams-for-linux
 onlyoffice-bin
 kvantum

--- a/configs/CLAUDE.md
+++ b/configs/CLAUDE.md
@@ -21,7 +21,7 @@ Template configuration files copied to user's `~/.config/` during setup.
 | `kde/`          | KDE Ocean theme bundle (5 components)   | Modifying KDE theme deployment            |
 | `zed/`          | Zed editor config (sanitized backup)    | Modifying Zed settings, themes            |
 | `caelestia/`    | Caelestia user prefs (`hypr-user.conf`, `cli.json`) | Modifying workspace pins, keybinds, special-workspace toggles |
-| `audio/`        | PipeWire/WirePlumber drop-in configs for bit-perfect audio (portable pipewire + device-routed wireplumber variants) | Modifying audio config, adding device-specific WirePlumber rules |
+| `audio/`        | PipeWire/WirePlumber drop-in configs (portable PipeWire + device-routed WirePlumber variants; PC has the lossless headset rule) | Modifying audio config, adding device-specific WirePlumber rules |
 | `mimeapps/`     | XDG default-application associations (`mimeapps.list`) — fully portable, no device routing | Changing default apps for MIME types or URI scheme handlers |
 | `scripts/`      | Executable shell wrappers deployed to `~/.local/bin/` | Adding PATH-shadow wrappers, game-launch hooks |
 | `caelestia-lockfix/` | Caelestia lock-screen portrait-fix kit (`apply.sh` + two QML patches) — workaround for upstream Caelestia bug | Updating the portrait-fix patch or re-seeding after a caelestia-shell update |

--- a/configs/audio/CLAUDE.md
+++ b/configs/audio/CLAUDE.md
@@ -1,6 +1,6 @@
 # configs/audio/
 
-PipeWire and WirePlumber drop-in config files for bit-perfect lossless audio playback.
+PipeWire and WirePlumber drop-in config files for audio-rate handling.
 
 ## Files
 
@@ -17,15 +17,15 @@ The two **PipeWire** drop-ins (`pipewire.conf.d/` and `pipewire-pulse.conf.d/`) 
 The **WirePlumber** drop-in is **device-specific**: it hardcodes the Logitech G PRO X headset by its `node.name`, which is unique to this PC. It therefore lives under a per-device subdirectory:
 
 - `deviceType === "pc"`     → deploys from `wireplumber/pc/`     → `~/.config/wireplumber/wireplumber.conf.d/`
-- `deviceType === "laptop"` → deploys from `wireplumber/laptop/` → `~/.config/wireplumber/wireplumber.conf.d/`
-- Anything else (unset, malformed, `"other"`) → falls back to the PC variant.
+- `deviceType === "laptop"` → no WirePlumber rule currently ships; laptop does not need the lossless hard-pin setup
+- Anything else (unset, malformed, `"other"`) → skip device-specific WirePlumber rules
 
 This mirrors the pattern already used in `configs/caelestia/` where `hypr-user-pc.conf` vs `hypr-user-laptop.conf` are routed by the `deviceType` field in `~/.haoshoku.json`.
 
-The `src/helpers/configure_audio.js` helper reads `deviceType`, syncs the portable PipeWire drop-ins, and deploys the matching WirePlumber variant. Run `haoshoku --audio` to deploy `configs/audio/` into `~/.config/`, and `haoshoku --audio-backup` to snapshot the live configs back.
+The `src/helpers/configure_audio.js` helper reads `deviceType`, syncs the portable PipeWire drop-ins, and deploys a matching WirePlumber variant only when a known variant exists. Run `haoshoku --audio` to deploy `configs/audio/` into `~/.config/`, and `haoshoku --audio-backup` to snapshot the live configs back.
 
 ## Notes
 
 - `51-logitech-prox-44100.conf` matches the node by the exact string `alsa_output.usb-Logitech_PRO_X_000000000000-00.analog-stereo`. If the USB serial changes or a different headset is used on the PC, update this `node.name` to match.
-- When adding a laptop variant, create `wireplumber/laptop/<name>.conf` with the equivalent rule for the laptop's audio output node.
+- Laptop currently has no WirePlumber rule. If that changes, create `wireplumber/laptop/<name>.conf` with a laptop-specific output node rather than reusing the PC headset rule.
 - These files were originally created following the `linux-lossless-setup` Notion runbook (2026-05-21).

--- a/configs/caelestia-lockfix/apply.sh
+++ b/configs/caelestia-lockfix/apply.sh
@@ -85,4 +85,5 @@ else
     [ -f "$DIR/Center.qml.orig" ] && sudo cp -a "$DIR/Center.qml.orig" "$DIR/Center.qml"
     caelestia shell -k 2>/dev/null; sleep 1.5; caelestia shell -d 2>/dev/null
     echo "  ↩ reverted; shell restarted with the originals."
+    exit 1
 fi

--- a/configs/caelestia-lockfix/apply.sh
+++ b/configs/caelestia-lockfix/apply.sh
@@ -84,6 +84,12 @@ else
     sudo cp -a "$DIR/LockSurface.qml.orig" "$DIR/LockSurface.qml"
     [ -f "$DIR/Center.qml.orig" ] && sudo cp -a "$DIR/Center.qml.orig" "$DIR/Center.qml"
     caelestia shell -k 2>/dev/null; sleep 1.5; caelestia shell -d 2>/dev/null
-    echo "  ↩ reverted; shell restarted with the originals."
-    exit 1
+    echo "  waiting for the reverted shell to come back..."
+    sleep 4
+    if pgrep -af 'qs -c caelestia' >/dev/null; then
+        echo "  ↩ reverted; shell restarted with the originals."
+    else
+        echo "  ✗ reverted; shell restart failed. Check Caelestia manually."
+    fi
+    exit 2
 fi

--- a/configs/caelestia/CLAUDE.md
+++ b/configs/caelestia/CLAUDE.md
@@ -7,7 +7,7 @@ Caelestia personal preferences (user-side overrides sourced last by Caelestia).
 | File                    | What                                                           | When to read                                                    |
 | ----------------------- | -------------------------------------------------------------- | --------------------------------------------------------------- |
 | `hypr-user-pc.conf`     | PC variant: 3 monitors (DP-1/DP-2/HDMI-A-1), NVIDIA exec-once, workspace-to-monitor pins | Modifying PC monitor layout, workspace pins, NVIDIA defaults  |
-| `hypr-user-laptop.conf` | Laptop variant: single eDP-1 HiDPI panel, Intel iGPU, no monitor pins | Modifying laptop monitor layout or laptop-specific overrides  |
+| `hypr-user-laptop.conf` | Laptop variant: same keybindings/workspaces/app routing as PC, single eDP-1 HiDPI panel, Intel iGPU, no monitor pins or VRR adjustment | Modifying laptop monitor layout or laptop-specific overrides  |
 | `cli.json`              | Caelestia CLI overrides for `caelestia toggle <ws>` (portable across devices) | Adding/removing special-workspace toggle apps                 |
 
 ## How deviceType selection works

--- a/configs/caelestia/hypr-user-laptop.conf
+++ b/configs/caelestia/hypr-user-laptop.conf
@@ -31,10 +31,11 @@ bind = $kbEditor, exec, app2unit -- $editor
 unbind = $kbBrowser
 bind = $kbBrowser, exec, caelestia toggle brave-work
 
-# Messaging workspace. `persistent` keeps ws 5 alive when empty, `default` makes
-# the session boot there when no monitor-specific default overrides it. `silent`
-# on the windowrule prevents focus stealing when a chat client spawns a window in
-# the background. Super+5 opens both mapped chat apps if either one is missing.
+# Messaging workspace. `persistent` keeps ws 5 alive when empty. `default:true`
+# mirrors the PC variant's default workspace set; without monitor pins, laptop
+# maps those defaults onto the active single output. `silent` on the windowrule
+# prevents focus stealing when a chat client spawns a window in the background.
+# Super+5 opens both mapped chat apps if either one is missing.
 workspace = 5, default:true, persistent:true
 windowrule = workspace 5 silent, match:class (teams-for-linux|TelegramDesktop|org\.telegram\.desktop)
 unbind = $kbGoToWs, 5

--- a/configs/caelestia/hypr-user-laptop.conf
+++ b/configs/caelestia/hypr-user-laptop.conf
@@ -10,8 +10,7 @@ monitor = eDP-1, 2880x1800@120, 0x0, 1.6
 # of eDP-1 at its preferred mode.
 monitor = , preferred, auto, 1
 
-# (No NVIDIA exec-once: this laptop has Intel iGPU only. If you ever drive an
-# NVIDIA dGPU and hit P-state flicker, see docs/hyprland-vrr-fix.md.)
+# (No NVIDIA exec-once: this laptop has Intel iGPU only.)
 
 # ─── Cross-desktop daemons (autostart) ───
 # kdeconnectd: phone↔desktop sync. Hyprland doesn't process XDG autostart, so the
@@ -27,61 +26,76 @@ $editor = zeditor
 unbind = $kbEditor
 bind = $kbEditor, exec, app2unit -- $editor
 
-# Super+W toggles the work-Brave (DEFI named window) special workspace
+# Super+W toggles the work-Brave special workspace (DEFI named window in the Defi
+# profile, which lives on disk as Brave's `Profile 3`).
 unbind = $kbBrowser
 bind = $kbBrowser, exec, caelestia toggle brave-work
 
-# "Minimize" via a stash special workspace. Super+H stashes the focused window
-# silently; Super+Shift+H toggles the stash overlay.
-bind = Super, H, movetoworkspacesilent, special:stash
-bind = Super+Shift, H, togglespecialworkspace, stash
-
-# Special-workspace toggles
-bind = Super, O, exec, caelestia toggle 1password
-unbind = $kbMusic
-bind = $kbMusic, exec, caelestia toggle music
-bind = Super, B, exec, caelestia toggle brave-personal
-bind = Super, A, exec, caelestia toggle claude
+# Messaging workspace. `persistent` keeps ws 5 alive when empty, `default` makes
+# the session boot there when no monitor-specific default overrides it. `silent`
+# on the windowrule prevents focus stealing when a chat client spawns a window in
+# the background. Super+5 opens both mapped chat apps if either one is missing.
+workspace = 5, default:true, persistent:true
+windowrule = workspace 5 silent, match:class (teams-for-linux|TelegramDesktop|org\.telegram\.desktop)
+unbind = $kbGoToWs, 5
+bind = $kbGoToWs, 5, exec, sh -lc 'hyprctl dispatch workspace 5; clients=$(hyprctl clients -j); printf "%s" "$clients" | jq -e '\''any(.[]; .class == "teams-for-linux")'\'' >/dev/null || hyprctl dispatch exec "[workspace 5 silent] app2unit -- teams-for-linux --gtk-version=3"; printf "%s" "$clients" | jq -e '\''any(.[]; .class == "TelegramDesktop" or .class == "org.telegram.desktop")'\'' >/dev/null || hyprctl dispatch exec "[workspace 5 silent] app2unit -- Telegram"'
 
 # Extend Caelestia's special:communication windowrule for Signal + the Brave
 # WhatsApp-Web PWA. The Brave PWA class is profile-specific.
 windowrule = workspace special:communication, match:class signal
 windowrule = workspace special:communication, match:class brave-hnpfjngllnobngcgfapefoaidbinmjnm-Default
 
-# 1Password (runtime WM class is lowercase "1password" despite the .desktop hint).
-windowrule = workspace special:1password, match:class 1password
-
 # Spotify uses Caelestia's music special workspace.
 windowrule = workspace special:music, match:class spotify|Spotify
+unbind = $kbMusic
+bind = $kbMusic, exec, caelestia toggle music
+
+# Notion workspace: named "0" so it sorts/displays as workspace 0 in the bar.
+# Notion runs as a Brave PWA (app-id adaalabfemebkikihnkbonlockjjpbml, Default profile).
+workspace = name:0, default:true, persistent:true
+windowrule = workspace name:0 silent, match:class brave-adaalabfemebkikihnkbonlockjjpbml-Default
+
+# Rebind Super+0 to go to the Notion workspace. If the Notion PWA has no window
+# yet, launch it into the named workspace.
+unbind = $kbGoToWs, 0
+bind = $kbGoToWs, 0, exec, sh -lc 'hyprctl dispatch workspace name:0; hyprctl clients -j | jq -e '\''any(.[]; .class == "brave-adaalabfemebkikihnkbonlockjjpbml-Default")'\'' >/dev/null || hyprctl dispatch exec "[workspace name:0 silent] app2unit -- /opt/brave-bin/brave --profile-directory=Default --app-id=adaalabfemebkikihnkbonlockjjpbml"'
+unbind = $kbMoveWinToWs, 0
+bind = $kbMoveWinToWs, 0, exec, hyprctl dispatch movetoworkspace name:0
+
+# Steam workspace. Catches the Steam launcher and its satellite windows (friends
+# list, downloads, etc.) which all share class=Steam.
+workspace = 2, persistent:true
+windowrule = workspace 2 silent, match:class ^[Ss]team$
+unbind = $kbGoToWs, 2
+bind = $kbGoToWs, 2, exec, sh -lc 'hyprctl dispatch workspace 2; hyprctl clients -j | jq -e '\''any(.[]; .class | test("^[Ss]team$"))'\'' >/dev/null || hyprctl dispatch exec "[workspace 2 silent] app2unit -- steam"'
+
+# "Minimize" approximations via a stash special workspace.
+bind = Super, H, movetoworkspacesilent, special:stash
+bind = Super+Shift, H, togglespecialworkspace, stash
+
+# 1Password as a roaming special workspace.
+windowrule = workspace special:1password, match:class 1password
+bind = Super, O, exec, caelestia toggle 1password
 
 # Brave profile windows each live in their own special workspace.
 windowrule = workspace special:brave-personal, match:class brave-browser, match:title Flux
+bind = Super, B, exec, caelestia toggle brave-personal
 windowrule = workspace special:brave-work, match:class brave-browser, match:title Defi
 
 # Claude Code in kitty with a distinct WM class so it doesn't catch other kitties.
 windowrule = workspace special:claude, match:class kitty-claude
+bind = Super, A, exec, caelestia toggle claude
 
-# Persistent workspaces — NO monitor: pins (single screen, no point anchoring).
-# Cohesion's named workspace, default at boot, persistent.
-workspace = name:0, default:true, persistent:true
-# Other persistent workspaces (work messaging, gaming-Vesktop, primary work).
-workspace = 1, persistent:true
-workspace = 5, persistent:true
+# Persistent workspaces. These intentionally have no monitor pins on laptop.
+workspace = 1, default:true, persistent:true
+workspace = 3, persistent:true
+
+# Vesktop workspace.
 workspace = 4, persistent:true
-
-# App routing to workspaces (silent so focus doesn't yank when chat windows spawn)
-windowrule = workspace 5 silent, match:class (teams-for-linux|TelegramDesktop|org\.telegram\.desktop)
 windowrule = workspace 4 silent, match:class vesktop
-windowrule = workspace name:0 silent, match:class cohesion
-
-# Workspace app bindings: jump to the workspace, then launch any mapped app that
-# does not already have a window. Workspace 5 intentionally launches both chat apps.
-# Super+0 bypasses Caelestia's group math because this is a named workspace.
-unbind = $kbGoToWs, 0
-bind = $kbGoToWs, 0, exec, sh -lc 'hyprctl dispatch workspace name:0; hyprctl clients -j | jq -e '\''any(.[]; .class == "cohesion")'\'' >/dev/null || hyprctl dispatch exec "[workspace name:0 silent] app2unit -- flatpak run io.github.brunofin.Cohesion"'
 unbind = $kbGoToWs, 4
 bind = $kbGoToWs, 4, exec, sh -lc 'hyprctl dispatch workspace 4; hyprctl clients -j | jq -e '\''any(.[]; .class == "vesktop")'\'' >/dev/null || hyprctl dispatch exec "[workspace 4 silent] app2unit -- vesktop"'
-unbind = $kbGoToWs, 5
-bind = $kbGoToWs, 5, exec, sh -lc 'hyprctl dispatch workspace 5; clients=$(hyprctl clients -j); printf "%s" "$clients" | jq -e '\''any(.[]; .class == "teams-for-linux")'\'' >/dev/null || hyprctl dispatch exec "[workspace 5 silent] app2unit -- teams-for-linux --gtk-version=3"; printf "%s" "$clients" | jq -e '\''any(.[]; .class == "TelegramDesktop" or .class == "org.telegram.desktop")'\'' >/dev/null || hyprctl dispatch exec "[workspace 5 silent] app2unit -- Telegram"'
-unbind = $kbMoveWinToWs, 0
-bind = $kbMoveWinToWs, 0, exec, hyprctl dispatch movetoworkspace name:0
+
+# Active-output screenshot. Kept aligned with the PC binding; on laptop this
+# captures the focused internal panel or the active external output when attached.
+bind = Super, Print, exec, hyprshot -m output -m active  # Capture focused monitor > clipboard

--- a/configs/mimeapps/applications/claude-code-url-handler.desktop
+++ b/configs/mimeapps/applications/claude-code-url-handler.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Claude Code URL Handler
+Comment=Handle claude-cli:// deep links for Claude Code
+Exec=claude --handle-uri %u
+Type=Application
+NoDisplay=true
+MimeType=x-scheme-handler/claude-cli;

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -108,6 +108,24 @@ export function copyDirRecursive(src, dest) {
 const KNOWN_DEVICE_TYPES = new Set(["pc", "laptop"]);
 const DEFAULT_DEVICE_TYPE = "pc";
 
+/** Return the explicitly configured known deviceType, or null when unset. */
+export function readConfiguredDeviceType(home) {
+	const stateFile = path.join(home, ".haoshoku.json");
+	if (!fs.existsSync(stateFile)) return null;
+	try {
+		const parsed = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+		if (
+			typeof parsed.deviceType === "string" &&
+			KNOWN_DEVICE_TYPES.has(parsed.deviceType)
+		) {
+			return parsed.deviceType;
+		}
+	} catch {
+		// Malformed JSON: fall through to unset.
+	}
+	return null;
+}
+
 /**
  * Read deviceType from ~/.haoshoku.json (populated by `haoshoku --hyprland`'s
  * promptDeviceType). Returns the literal string if it's a known variant
@@ -116,15 +134,5 @@ const DEFAULT_DEVICE_TYPE = "pc";
  * (e.g. `"other"`) all collapse to the safest mainstream default.
  */
 export function readDeviceType(home) {
-	const stateFile = path.join(home, ".haoshoku.json");
-	if (!fs.existsSync(stateFile)) return DEFAULT_DEVICE_TYPE;
-	try {
-		const parsed = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
-		if (typeof parsed.deviceType === "string" && KNOWN_DEVICE_TYPES.has(parsed.deviceType)) {
-			return parsed.deviceType;
-		}
-	} catch {
-		// Malformed JSON: fall through to default.
-	}
-	return DEFAULT_DEVICE_TYPE;
+	return readConfiguredDeviceType(home) ?? DEFAULT_DEVICE_TYPE;
 }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -31,6 +31,8 @@ export async function runCommand(command, options = { check: true }) {
 
 		const exitCode = await proc.exited;
 
+		if (options.returnExitCode) return exitCode;
+
 		if (options.check && exitCode !== 0) {
 			log.error(`Command '${command}' failed with exit code ${exitCode}`);
 			return false;
@@ -39,6 +41,7 @@ export async function runCommand(command, options = { check: true }) {
 	} catch (error) {
 		log.error(`Failed to execute command: ${command}`);
 		console.error(error);
+		if (options.returnExitCode) return 127;
 		return false;
 	}
 }
@@ -120,8 +123,10 @@ export function readConfiguredDeviceType(home) {
 		) {
 			return parsed.deviceType;
 		}
-	} catch {
-		// Malformed JSON: fall through to unset.
+	} catch (err) {
+		log.warning(
+			`Malformed ~/.haoshoku.json at ${stateFile}; treating deviceType as unset (${err?.message ?? err})`,
+		);
 	}
 	return null;
 }
@@ -130,8 +135,9 @@ export function readConfiguredDeviceType(home) {
  * Read deviceType from ~/.haoshoku.json (populated by `haoshoku --hyprland`'s
  * promptDeviceType). Returns the literal string if it's a known variant
  * (`"pc"` or `"laptop"`); otherwise returns `DEFAULT_DEVICE_TYPE` (`"pc"`).
- * This means missing file / malformed JSON / absent key / unknown value
- * (e.g. `"other"`) all collapse to the safest mainstream default.
+ * This fallback is for config families where the PC variant is the safest
+ * mainstream default. Hardware-specific flows that must not guess (for example
+ * WirePlumber audio routing) should call readConfiguredDeviceType() instead.
  */
 export function readDeviceType(home) {
 	return readConfiguredDeviceType(home) ?? DEFAULT_DEVICE_TYPE;

--- a/src/helpers/configure_audio.js
+++ b/src/helpers/configure_audio.js
@@ -6,6 +6,8 @@ import { log, readConfiguredDeviceType } from "../common/utils.js";
 
 const HOME_DEFAULT = homedir();
 const PROJECT_ROOT_DEFAULT = path.resolve(__dirname, "..", "..");
+const MANAGED_WIREPLUMBER_MARKER =
+  "# Managed by Haoshoku: device-routed WirePlumber drop-in\n";
 
 /**
  * Resolve all live and in-repo audio config paths from injected home +
@@ -42,8 +44,9 @@ function resolvePaths({ home = HOME_DEFAULT, projectRoot = PROJECT_ROOT_DEFAULT 
  * @param {string} srcDir
  * @param {string} destDir
  * @param {string} label  — human-readable name used in log messages
+ * @param {{ transform?: (contents: string) => string }} opts
  */
-function copyDropInDir(srcDir, destDir, label) {
+function copyDropInDir(srcDir, destDir, label, { transform } = {}) {
   if (!fs.existsSync(srcDir)) {
     log.warning(`No ${label} source dir found at ${srcDir} — skipping`);
     return;
@@ -61,36 +64,141 @@ function copyDropInDir(srcDir, destDir, label) {
     const dest = path.join(destDir, file);
     // Only copy plain files; drop-in dirs are flat
     if (fs.statSync(src).isFile()) {
-      fs.copyFileSync(src, dest);
+      if (transform) {
+        fs.writeFileSync(dest, transform(fs.readFileSync(src, "utf8")));
+      } else {
+        fs.copyFileSync(src, dest);
+      }
       log.info(`Synced ${label}/${file}`);
     }
   }
 }
 
-function managedWireplumberFiles(audioBackupDir) {
-  const wireplumberRoot = path.join(audioBackupDir, "wireplumber");
-  const managed = new Set();
-  if (!fs.existsSync(wireplumberRoot)) return managed;
+function withManagedWireplumberMarker(contents) {
+  if (contents.startsWith(MANAGED_WIREPLUMBER_MARKER)) return contents;
+  return `${MANAGED_WIREPLUMBER_MARKER}${contents}`;
+}
 
-  for (const deviceDir of fs.readdirSync(wireplumberRoot, { withFileTypes: true })) {
+function withoutManagedWireplumberMarker(contents) {
+  if (!contents.startsWith(MANAGED_WIREPLUMBER_MARKER)) return contents;
+  return contents.slice(MANAGED_WIREPLUMBER_MARKER.length);
+}
+
+function warnFs(action, target, err) {
+  log.warning(`${action} ${target}: ${err?.message ?? err}`);
+}
+
+/**
+ * Read repo WirePlumber variants as deviceType -> filename -> file contents.
+ * Contents give stale-prune a provenance check for files deployed by older
+ * Haoshoku versions before the explicit managed marker existed.
+ */
+function managedWireplumberVariants(audioBackupDir) {
+  const wireplumberRoot = path.join(audioBackupDir, "wireplumber");
+  const variants = new Map();
+  if (!fs.existsSync(wireplumberRoot)) return variants;
+
+  let deviceDirs;
+  try {
+    deviceDirs = fs.readdirSync(wireplumberRoot, { withFileTypes: true });
+  } catch (err) {
+    warnFs("Could not read WirePlumber variants under", wireplumberRoot, err);
+    return variants;
+  }
+
+  for (const deviceDir of deviceDirs) {
     if (!deviceDir.isDirectory()) continue;
     const variantDir = path.join(wireplumberRoot, deviceDir.name);
-    for (const file of fs.readdirSync(variantDir, { withFileTypes: true })) {
-      if (file.isFile()) managed.add(file.name);
+    const managedFiles = new Map();
+    let files;
+    try {
+      files = fs.readdirSync(variantDir, { withFileTypes: true });
+    } catch (err) {
+      warnFs("Could not read WirePlumber variant dir", variantDir, err);
+      continue;
+    }
+
+    for (const file of files) {
+      if (!file.isFile()) continue;
+      const src = path.join(variantDir, file.name);
+      try {
+        managedFiles.set(file.name, fs.readFileSync(src, "utf8"));
+      } catch (err) {
+        warnFs("Could not read WirePlumber managed file", src, err);
+      }
+    }
+    variants.set(deviceDir.name, managedFiles);
+  }
+
+  return variants;
+}
+
+function staleWireplumberFiles(variants, deviceType) {
+  const currentFiles = deviceType
+    ? (variants.get(deviceType) ?? new Map())
+    : new Map();
+  const stale = new Map();
+
+  for (const [variant, files] of variants) {
+    if (variant === deviceType) continue;
+    for (const [file, contents] of files) {
+      if (currentFiles.has(file)) continue;
+      if (!stale.has(file)) stale.set(file, []);
+      stale.get(file).push(contents);
     }
   }
 
-  return managed;
+  return stale;
 }
 
-function pruneManagedDropIns(destDir, managedFiles) {
+function isManagedWireplumberFile(liveContent, managedContents) {
+  if (liveContent.startsWith(MANAGED_WIREPLUMBER_MARKER)) return true;
+  return managedContents.some(
+    (contents) =>
+      liveContent === contents ||
+      liveContent === withManagedWireplumberMarker(contents),
+  );
+}
+
+function pruneManagedDropIns(destDir, staleFiles) {
   if (!fs.existsSync(destDir)) return;
 
-  for (const file of managedFiles) {
+  for (const [file, managedContents] of staleFiles) {
     const dest = path.join(destDir, file);
-    if (fs.existsSync(dest) && fs.statSync(dest).isFile()) {
+    let stat;
+    try {
+      stat = fs.statSync(dest);
+    } catch (err) {
+      if (err?.code !== "ENOENT") {
+        warnFs("Could not stat WirePlumber drop-in", dest, err);
+      }
+      continue;
+    }
+
+    if (!stat.isFile()) continue;
+
+    let liveContent;
+    try {
+      liveContent = fs.readFileSync(dest, "utf8");
+    } catch (err) {
+      warnFs("Could not inspect WirePlumber drop-in", dest, err);
+      continue;
+    }
+
+    if (!isManagedWireplumberFile(liveContent, managedContents)) {
+      log.warning(
+        `Leaving user-authored wireplumber/${file} untouched (filename matches a managed variant, but no Haoshoku marker/content match was found)`,
+      );
+      continue;
+    }
+
+    try {
       fs.unlinkSync(dest);
       log.info(`Removed stale wireplumber/${file}`);
+    } catch (err) {
+      if (err?.code !== "ENOENT") {
+        warnFs("Could not remove stale WirePlumber drop-in", dest, err);
+      }
     }
   }
 }
@@ -104,6 +212,10 @@ function pruneManagedDropIns(destDir, managedFiles) {
  *
  * Device-routed WirePlumber drop-ins:
  *   configs/audio/wireplumber/<deviceType>/       → ~/.config/wireplumber/wireplumber.conf.d/
+ *
+ * WirePlumber files are stamped with a Haoshoku marker. Stale pruning only
+ * removes files from other variants when that marker or exact old managed
+ * content proves Haoshoku deployed them.
  *
  * Missing source dirs are skipped with a warning — partial sync is intentional.
  */
@@ -129,9 +241,10 @@ export async function syncAudioConfig(opts = {}) {
     "pipewire-pulse.conf.d",
   );
 
+  const wireplumberVariants = managedWireplumberVariants(audioBackupDir);
   pruneManagedDropIns(
     liveWireplumberConfD,
-    managedWireplumberFiles(audioBackupDir),
+    staleWireplumberFiles(wireplumberVariants, deviceType),
   );
 
   if (!deviceType) {
@@ -152,6 +265,7 @@ export async function syncAudioConfig(opts = {}) {
     repoWireplumberDevice,
     liveWireplumberConfD,
     `wireplumber/${deviceType}`,
+    { transform: withManagedWireplumberMarker },
   );
 
   log.success("Audio config synced to ~/.config/");
@@ -164,7 +278,9 @@ export async function syncAudioConfig(opts = {}) {
  * ~/.config/pipewire/pipewire-pulse.conf.d/ → configs/audio/pipewire/pipewire-pulse.conf.d/
  * ~/.config/wireplumber/wireplumber.conf.d/ → configs/audio/wireplumber/<deviceType>/
  *
- * Missing live dirs are skipped with a warning.
+ * Missing live dirs are skipped with a warning. Without an explicit pc/laptop
+ * deviceType, WirePlumber backup is skipped because the repo has no neutral
+ * device-routed target.
  */
 export async function backupAudioConfig(opts = {}) {
   const {
@@ -190,7 +306,7 @@ export async function backupAudioConfig(opts = {}) {
 
   if (!deviceType) {
     log.warning(
-      "No explicit deviceType in ~/.haoshoku.json — skipping device-specific WirePlumber backup",
+      "No explicit deviceType in ~/.haoshoku.json — skipping device-specific WirePlumber backup; choose pc/laptop before backing up device-routed audio rules",
     );
     log.success("Audio config backed up to configs/audio/");
     return;
@@ -206,6 +322,7 @@ export async function backupAudioConfig(opts = {}) {
     liveWireplumberConfD,
     repoWireplumberDevice,
     `wireplumber/${deviceType}`,
+    { transform: withoutManagedWireplumberMarker },
   );
 
   log.success("Audio config backed up to configs/audio/");

--- a/src/helpers/configure_audio.js
+++ b/src/helpers/configure_audio.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
-import { log, readDeviceType } from "../common/utils.js";
+import { log, readConfiguredDeviceType } from "../common/utils.js";
 
 const HOME_DEFAULT = homedir();
 const PROJECT_ROOT_DEFAULT = path.resolve(__dirname, "..", "..");
@@ -67,6 +67,34 @@ function copyDropInDir(srcDir, destDir, label) {
   }
 }
 
+function managedWireplumberFiles(audioBackupDir) {
+  const wireplumberRoot = path.join(audioBackupDir, "wireplumber");
+  const managed = new Set();
+  if (!fs.existsSync(wireplumberRoot)) return managed;
+
+  for (const deviceDir of fs.readdirSync(wireplumberRoot, { withFileTypes: true })) {
+    if (!deviceDir.isDirectory()) continue;
+    const variantDir = path.join(wireplumberRoot, deviceDir.name);
+    for (const file of fs.readdirSync(variantDir, { withFileTypes: true })) {
+      if (file.isFile()) managed.add(file.name);
+    }
+  }
+
+  return managed;
+}
+
+function pruneManagedDropIns(destDir, managedFiles) {
+  if (!fs.existsSync(destDir)) return;
+
+  for (const file of managedFiles) {
+    const dest = path.join(destDir, file);
+    if (fs.existsSync(dest) && fs.statSync(dest).isFile()) {
+      fs.unlinkSync(dest);
+      log.info(`Removed stale wireplumber/${file}`);
+    }
+  }
+}
+
 /**
  * Deploy repo audio drop-ins → live ~/.config/.
  *
@@ -90,8 +118,8 @@ export async function syncAudioConfig(opts = {}) {
     repoPipewirePulseConfD,
   } = resolvePaths(opts);
 
-  const deviceType = readDeviceType(home);
-  log.info(`Syncing audio config (deviceType=${deviceType})...`);
+  const deviceType = readConfiguredDeviceType(home);
+  log.info(`Syncing audio config (deviceType=${deviceType ?? "unset"})...`);
 
   // Portable PipeWire drop-ins
   copyDropInDir(repoPipewireConfD, livePipewireConfD, "pipewire.conf.d");
@@ -100,6 +128,19 @@ export async function syncAudioConfig(opts = {}) {
     livePipewirePulseConfD,
     "pipewire-pulse.conf.d",
   );
+
+  pruneManagedDropIns(
+    liveWireplumberConfD,
+    managedWireplumberFiles(audioBackupDir),
+  );
+
+  if (!deviceType) {
+    log.warning(
+      "No explicit deviceType in ~/.haoshoku.json — skipping device-specific WirePlumber drop-ins",
+    );
+    log.success("Audio config synced to ~/.config/");
+    return;
+  }
 
   // Device-routed WirePlumber drop-ins
   const repoWireplumberDevice = path.join(
@@ -136,8 +177,8 @@ export async function backupAudioConfig(opts = {}) {
     repoPipewirePulseConfD,
   } = resolvePaths(opts);
 
-  const deviceType = readDeviceType(home);
-  log.info(`Backing up audio config (deviceType=${deviceType})...`);
+  const deviceType = readConfiguredDeviceType(home);
+  log.info(`Backing up audio config (deviceType=${deviceType ?? "unset"})...`);
 
   // Portable PipeWire drop-ins
   copyDropInDir(livePipewireConfD, repoPipewireConfD, "pipewire.conf.d");
@@ -146,6 +187,14 @@ export async function backupAudioConfig(opts = {}) {
     repoPipewirePulseConfD,
     "pipewire-pulse.conf.d",
   );
+
+  if (!deviceType) {
+    log.warning(
+      "No explicit deviceType in ~/.haoshoku.json — skipping device-specific WirePlumber backup",
+    );
+    log.success("Audio config backed up to configs/audio/");
+    return;
+  }
 
   // Device-routed WirePlumber drop-ins (live → repo/<deviceType>/)
   const repoWireplumberDevice = path.join(

--- a/src/helpers/configure_hyprland.js
+++ b/src/helpers/configure_hyprland.js
@@ -328,12 +328,20 @@ export async function installCaelestia({
 			"caelestia-lockfix",
 			"apply.sh",
 		);
-		const applied = await run(`bash ${applyScript}`);
-		if (applied) {
+		const applied = await run(`bash ${applyScript}`, {
+			check: false,
+			returnExitCode: true,
+		});
+		if (applied === 0 || applied === true) {
 			log.success("caelestia-lockfix portrait fix applied.");
+		} else if (applied === 2) {
+			log.warning(
+				"caelestia-lockfix apply.sh auto-reverted because Caelestia shell did not restart. " +
+					"Check whether the shell is running, then run `~/.local/share/caelestia-lockfix/apply.sh` manually after setup.",
+			);
 		} else {
 			log.warning(
-				"caelestia-lockfix apply.sh exited non-zero — portrait fix not applied. " +
+				"caelestia-lockfix apply.sh could not apply the patch — portrait fix not applied. " +
 					"Run `~/.local/share/caelestia-lockfix/apply.sh` manually after setup.",
 			);
 		}
@@ -390,8 +398,8 @@ export async function promptDesktopEnvironment({
  * ~/.haoshoku.json (merged with any existing keys — e.g. skillSources).
  * On skip or cancel, returns null and does NOT touch the file.
  *
- * 5.0.0 captures this answer but doesn't yet consume it — future per-host
- * monitor configuration will read `deviceType` from the same file.
+ * The answer routes Caelestia monitor/workspace prefs and device-specific
+ * audio tuning; skip/cancel leaves those device-routed paths unset.
  */
 export async function promptDeviceType({
 	configPath = path.join(HOME, ".haoshoku.json"),
@@ -417,9 +425,10 @@ export async function promptDeviceType({
 	if (fs.existsSync(configPath)) {
 		try {
 			config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-		} catch {
-			// Corrupt config — overwrite rather than crash. Other keys are lost
-			// in this edge case, but a corrupt JSON file was already lost.
+		} catch (err) {
+			log.warning(
+				`Malformed ~/.haoshoku.json at ${configPath}; replacing it while saving deviceType (${err?.message ?? err})`,
+			);
 			config = {};
 		}
 	}

--- a/src/helpers/configure_mimeapps.js
+++ b/src/helpers/configure_mimeapps.js
@@ -40,7 +40,8 @@ function syncDesktopHandlers(repoApplicationsDir, liveApplicationsDir) {
 }
 
 /**
- * Deploy configs/mimeapps/mimeapps.list → ~/.config/mimeapps.list.
+ * Deploy configs/mimeapps/mimeapps.list → ~/.config/mimeapps.list and any
+ * repo-authored .desktop handlers → ~/.local/share/applications/.
  *
  * Creates ~/.config/ if missing. If the repo source file is absent, logs a
  * warning and skips (partial-sync is intentional — no error thrown).
@@ -69,6 +70,8 @@ export async function syncMimeappsConfig(opts = {}) {
 
 /**
  * Snapshot ~/.config/mimeapps.list → configs/mimeapps/mimeapps.list.
+ * Repo-authored .desktop handlers are intentionally not backed up from the
+ * live system; they are managed assets, not user-edited runtime state.
  *
  * Creates the repo dir if missing. If the live file is absent, logs a
  * warning and skips.
@@ -88,7 +91,7 @@ export async function backupMimeappsConfig(opts = {}) {
   log.success("mimeapps.list backed up to configs/mimeapps/");
 }
 
-/** Alias used by OS setup flows; mirrors configureAudio(). */
+/** Alias used by OS setup flows; deploys the portable MIME/app handler defaults. */
 export async function configureMimeapps(opts = {}) {
   await syncMimeappsConfig(opts);
 }

--- a/src/helpers/configure_mimeapps.js
+++ b/src/helpers/configure_mimeapps.js
@@ -18,9 +18,25 @@ function resolvePaths({ home = HOME_DEFAULT, projectRoot = PROJECT_ROOT_DEFAULT 
   return {
     liveFile: path.join(home, ".config", "mimeapps.list"),
     liveDir: path.join(home, ".config"),
+    liveApplicationsDir: path.join(home, ".local", "share", "applications"),
     repoFile: path.join(projectRoot, "configs", "mimeapps", "mimeapps.list"),
     repoDir: path.join(projectRoot, "configs", "mimeapps"),
+    repoApplicationsDir: path.join(projectRoot, "configs", "mimeapps", "applications"),
   };
+}
+
+function syncDesktopHandlers(repoApplicationsDir, liveApplicationsDir) {
+  if (!fs.existsSync(repoApplicationsDir)) return;
+
+  fs.mkdirSync(liveApplicationsDir, { recursive: true });
+  for (const entry of fs.readdirSync(repoApplicationsDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".desktop")) continue;
+    fs.copyFileSync(
+      path.join(repoApplicationsDir, entry.name),
+      path.join(liveApplicationsDir, entry.name),
+    );
+    log.info(`Synced applications/${entry.name}`);
+  }
 }
 
 /**
@@ -32,7 +48,13 @@ function resolvePaths({ home = HOME_DEFAULT, projectRoot = PROJECT_ROOT_DEFAULT 
  * @param {{ home?: string, projectRoot?: string }} opts
  */
 export async function syncMimeappsConfig(opts = {}) {
-  const { liveFile, liveDir, repoFile } = resolvePaths(opts);
+  const {
+    liveFile,
+    liveDir,
+    liveApplicationsDir,
+    repoFile,
+    repoApplicationsDir,
+  } = resolvePaths(opts);
 
   if (!fs.existsSync(repoFile)) {
     log.warning(`No mimeapps.list source found at ${repoFile} — skipping`);
@@ -41,6 +63,7 @@ export async function syncMimeappsConfig(opts = {}) {
 
   fs.mkdirSync(liveDir, { recursive: true });
   fs.copyFileSync(repoFile, liveFile);
+  syncDesktopHandlers(repoApplicationsDir, liveApplicationsDir);
   log.success("mimeapps.list synced to ~/.config/");
 }
 

--- a/src/os_scripts/cachyos.js
+++ b/src/os_scripts/cachyos.js
@@ -454,7 +454,9 @@ async function configureHyprland() {
   }
   const device = await promptDeviceType();
   if (device === null) {
-    log.info("Device type skipped (no entry written to ~/.haoshoku.json).");
+    log.info(
+      "Device type skipped (no entry written to ~/.haoshoku.json); device-specific audio/WirePlumber tuning will be skipped.",
+    );
   } else {
     log.info(`Recorded device type as '${device}' in ~/.haoshoku.json.`);
   }
@@ -562,7 +564,13 @@ async function configureUserApps() {
   await configureMimeapps();
   await configureKde();
   await configureHyprland();
-  await configureAudio();
+  try {
+    await configureAudio();
+  } catch (err) {
+    log.warning(
+      `Audio config sync failed (${err?.message ?? err}) — continuing with remaining app setup.`,
+    );
+  }
 
   // Fish + Fastfetch deploy AFTER configureHyprland because Caelestia's
   // install.fish overwrites ~/.config/fish/config.fish,

--- a/src/os_scripts/cachyos.js
+++ b/src/os_scripts/cachyos.js
@@ -559,10 +559,10 @@ async function configureUserApps() {
 
   await configureTerminals();
   await configureZed();
-  await configureAudio();
   await configureMimeapps();
   await configureKde();
   await configureHyprland();
+  await configureAudio();
 
   // Fish + Fastfetch deploy AFTER configureHyprland because Caelestia's
   // install.fish overwrites ~/.config/fish/config.fish,

--- a/tests/cachyos.test.js
+++ b/tests/cachyos.test.js
@@ -54,6 +54,15 @@ describe("configureUserApps step ordering", () => {
     expect(audio.index).toBeGreaterThan(hyprland.index);
   });
 
+  it("guards configureAudio so audio sync errors do not abort later app setup", () => {
+    expect(CACHYOS_SRC).toMatch(
+      /try\s*\{\s*await configureAudio\(\);\s*\}\s*catch\s*\(err\)\s*\{\s*log\.warning/s,
+    );
+    expect(callIndex("configureFishShell").index).toBeGreaterThan(
+      callIndex("configureAudio").index,
+    );
+  });
+
   it("calls configureCaelestiaPrefs exactly once, after installCaelestia", () => {
     // Regression: v5.1.0 added --caelestia-prefs but forgot to wire it into the
     // default cachyos flow, so a fresh `haoshoku` install booted Hyprland with
@@ -116,6 +125,12 @@ describe("configureHyprland default-flow UX", () => {
   it("forwards skipHyprlandPackages based on the DE answer to installCaelestia", () => {
     expect(CACHYOS_SRC).toMatch(
       /installCaelestia\(\{\s*skipHyprlandPackages:\s*de\s*===\s*["']hyprland["']/,
+    );
+  });
+
+  it("tells skipped device-type users that device-specific audio tuning will be skipped", () => {
+    expect(CACHYOS_SRC).toMatch(
+      /Device type skipped[\s\S]{0,180}(audio|WirePlumber)/i,
     );
   });
 });

--- a/tests/cachyos.test.js
+++ b/tests/cachyos.test.js
@@ -47,6 +47,13 @@ describe("configureUserApps step ordering", () => {
     expect(fastfetch.index).toBeGreaterThan(hyprland.index);
   });
 
+  it("calls configureAudio exactly once, after configureHyprland captures device type", () => {
+    const hyprland = callIndex("configureHyprland");
+    const audio = callIndex("configureAudio");
+    expect(audio.count).toBe(1);
+    expect(audio.index).toBeGreaterThan(hyprland.index);
+  });
+
   it("calls configureCaelestiaPrefs exactly once, after installCaelestia", () => {
     // Regression: v5.1.0 added --caelestia-prefs but forgot to wire it into the
     // default cachyos flow, so a fresh `haoshoku` install booted Hyprland with
@@ -153,6 +160,18 @@ describe("AUR package list", () => {
       .map((l) => l.trim())
       .filter((l) => l && !l.startsWith("#"));
     expect(pkgs).toContain("thunar");
+  });
+
+  it("includes swayimg for the managed image MIME defaults", () => {
+    const list = fs.readFileSync(
+      path.join(PROJECT_ROOT, "common", "paru_applist.txt"),
+      "utf8",
+    );
+    const pkgs = list
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith("#"));
+    expect(pkgs).toContain("swayimg");
   });
 });
 

--- a/tests/common.test.js
+++ b/tests/common.test.js
@@ -29,4 +29,12 @@ describe("Common Files", () => {
 			});
 		});
 	});
+
+	it("does not install the retired Cohesion Flatpak", () => {
+		const content = fs.readFileSync(
+			path.join(COMMON_DIR, "flatpacks_arch.txt"),
+			"utf-8",
+		);
+		expect(content).not.toContain("io.github.brunofin.Cohesion");
+	});
 });

--- a/tests/configure_audio.test.js
+++ b/tests/configure_audio.test.js
@@ -298,6 +298,81 @@ describe("syncAudioConfig — device-routed WirePlumber drop-ins", () => {
 		]);
 	});
 
+	it("does not remove user-authored wireplumber files with managed-name collisions", async () => {
+		seedRepoFixtures({ pc: true, laptop: true });
+		const liveWireplumberDir = path.join(
+			tmpHome,
+			".config",
+			"wireplumber",
+			"wireplumber.conf.d",
+		);
+		fs.mkdirSync(liveWireplumberDir, { recursive: true });
+		const userFile = path.join(
+			liveWireplumberDir,
+			"51-logitech-prox-44100.conf",
+		);
+		const userContent = "# user-authored rule with a colliding filename\n";
+		fs.writeFileSync(userFile, userContent);
+
+		writeDeviceType("laptop");
+		await audio.syncAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot });
+
+		expect(fs.readFileSync(userFile, "utf8")).toBe(userContent);
+		expect(
+			fs.existsSync(path.join(liveWireplumberDir, "51-laptop-audio.conf")),
+		).toBe(true);
+	});
+
+	it("stamps deployed wireplumber drop-ins as Haoshoku-managed", async () => {
+		seedRepoFixtures({ pc: true });
+		writeDeviceType("pc");
+		await audio.syncAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot });
+
+		const destFile = path.join(
+			tmpHome,
+			".config",
+			"wireplumber",
+			"wireplumber.conf.d",
+			"51-logitech-prox-44100.conf",
+		);
+		expect(fs.readFileSync(destFile, "utf8")).toStartWith(
+			"# Managed by Haoshoku",
+		);
+	});
+
+	it("removes stale managed wireplumber files when deviceType becomes unset", async () => {
+		seedRepoFixtures({ pc: true });
+		writeDeviceType("pc");
+		await audio.syncAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot });
+
+		fs.rmSync(path.join(tmpHome, ".haoshoku.json"), { force: true });
+		await audio.syncAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot });
+
+		expect(
+			fs.existsSync(
+				path.join(
+					tmpHome,
+					".config",
+					"wireplumber",
+					"wireplumber.conf.d",
+					"51-logitech-prox-44100.conf",
+				),
+			),
+		).toBe(false);
+	});
+
+	it("skips stale prune gracefully when repo wireplumber dir is missing", async () => {
+		seedRepoFixtures({ pc: true });
+		fs.rmSync(path.join(tmpProjectRoot, "configs", "audio", "wireplumber"), {
+			recursive: true,
+			force: true,
+		});
+
+		await expect(
+			audio.syncAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot }),
+		).resolves.toBeUndefined();
+	});
+
 	it("creates ~/.config/wireplumber/wireplumber.conf.d/ if missing", async () => {
 		seedRepoFixtures({ pc: true });
 		writeDeviceType("pc");
@@ -307,12 +382,7 @@ describe("syncAudioConfig — device-routed WirePlumber drop-ins", () => {
 		await audio.syncAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot });
 		expect(
 			fs.existsSync(
-				path.join(
-					tmpHome,
-					".config",
-					"wireplumber",
-					"wireplumber.conf.d",
-				),
+				path.join(tmpHome, ".config", "wireplumber", "wireplumber.conf.d"),
 			),
 		).toBe(true);
 	});
@@ -468,6 +538,27 @@ describe("backupAudioConfig — snapshots live drop-ins into repo tree", () => {
 		);
 		expect(fs.existsSync(destFile)).toBe(true);
 		expect(fs.readFileSync(destFile, "utf8")).toMatch(/live wireplumber rule for pc/);
+	});
+
+	it("strips the live Haoshoku-managed marker when backing up wireplumber files", async () => {
+		seedRepoFixtures({ pc: true });
+		writeDeviceType("pc");
+		await audio.syncAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot });
+		await audio.backupAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot });
+
+		const backedUp = fs.readFileSync(
+			path.join(
+				tmpProjectRoot,
+				"configs",
+				"audio",
+				"wireplumber",
+				"pc",
+				"51-logitech-prox-44100.conf",
+			),
+			"utf8",
+		);
+		expect(backedUp).not.toStartWith("# Managed by Haoshoku");
+		expect(backedUp).toMatch(/pc wireplumber rule/);
 	});
 
 	it("backs up wireplumber.conf.d/ to wireplumber/laptop/ when deviceType=laptop", async () => {

--- a/tests/configure_audio.test.js
+++ b/tests/configure_audio.test.js
@@ -658,4 +658,20 @@ describe("seeded configs/audio/ (in-tree static configs)", () => {
 			),
 		).toBe(true);
 	});
+
+	it("does not ship a laptop lossless WirePlumber rule", () => {
+		const laptopDir = path.join(CONFIGS_AUDIO_DIR, "wireplumber", "laptop");
+		const laptopRules = fs.existsSync(laptopDir)
+			? fs.readdirSync(laptopDir).filter((file) => file.endsWith(".conf"))
+			: [];
+		expect(laptopRules).toEqual([]);
+	});
+
+	it("documents that unset, other, and laptop do not fall back to the PC lossless rule", () => {
+		const docs = fs.readFileSync(path.join(CONFIGS_AUDIO_DIR, "CLAUDE.md"), "utf8");
+		expect(docs).not.toMatch(/falls back to the PC variant/i);
+		expect(docs).toMatch(/laptop[^.\n]*no WirePlumber rule/i);
+		expect(docs).toMatch(/unset[^.\n]*skip/i);
+		expect(docs).toMatch(/other[^.\n]*skip/i);
+	});
 });

--- a/tests/configure_audio.test.js
+++ b/tests/configure_audio.test.js
@@ -261,7 +261,7 @@ describe("syncAudioConfig — device-routed WirePlumber drop-ins", () => {
 		expect(fs.existsSync(pcFile)).toBe(false);
 	});
 
-	it("falls back to pc variant when ~/.haoshoku.json is missing", async () => {
+	it("skips wireplumber files when ~/.haoshoku.json is missing", async () => {
 		seedRepoFixtures({ pc: true });
 		// No writeDeviceType call — no ~/.haoshoku.json
 		await audio.syncAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot });
@@ -276,7 +276,26 @@ describe("syncAudioConfig — device-routed WirePlumber drop-ins", () => {
 					"51-logitech-prox-44100.conf",
 				),
 			),
-		).toBe(true);
+		).toBe(false);
+	});
+
+	it("removes stale managed wireplumber files when deviceType changes", async () => {
+		seedRepoFixtures({ pc: true, laptop: true });
+		writeDeviceType("pc");
+		await audio.syncAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot });
+
+		writeDeviceType("laptop");
+		await audio.syncAudioConfig({ home: tmpHome, projectRoot: tmpProjectRoot });
+
+		const liveWireplumberDir = path.join(
+			tmpHome,
+			".config",
+			"wireplumber",
+			"wireplumber.conf.d",
+		);
+		expect(fs.readdirSync(liveWireplumberDir).sort()).toEqual([
+			"51-laptop-audio.conf",
+		]);
 	});
 
 	it("creates ~/.config/wireplumber/wireplumber.conf.d/ if missing", async () => {
@@ -530,6 +549,27 @@ describe("backupAudioConfig — snapshots live drop-ins into repo tree", () => {
 				path.join(tmpProjectRoot, "configs", "audio", "wireplumber", "pc"),
 			),
 		).toBe(true);
+	});
+
+	it("does not back up wireplumber files without an explicit deviceType", async () => {
+		seedLiveAudio({ deviceType: "pc" });
+		await audio.backupAudioConfig({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		expect(
+			fs.existsSync(
+				path.join(
+					tmpProjectRoot,
+					"configs",
+					"audio",
+					"wireplumber",
+					"pc",
+					"51-logitech-prox-44100.conf",
+				),
+			),
+		).toBe(false);
 	});
 });
 

--- a/tests/configure_caelestia_prefs.test.js
+++ b/tests/configure_caelestia_prefs.test.js
@@ -482,10 +482,55 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 		expect(conf).toMatch(/monitor\s*=\s*,\s*preferred/);
 		// NO NVIDIA exec-once on Intel iGPU laptop
 		expect(conf).not.toMatch(/nvidia-settings/);
+		expect(conf).not.toMatch(/\bvrr\b/);
 		// Workspaces should be persistent but NOT monitor-pinned
 		expect(conf).toMatch(/workspace\s*=\s*name:0/);
 		expect(conf).not.toMatch(/workspace\s*=\s*\d+\s*,\s*monitor:/);
 		expect(conf).not.toMatch(/workspace\s*=\s*name:0\s*,\s*monitor:/);
+	});
+
+	it("uses the Notion Brave PWA on laptop instead of the retired Cohesion app", () => {
+		const conf = fs.readFileSync(
+			path.join(CONFIGS_CAELESTIA_DIR, "hypr-user-laptop.conf"),
+			"utf8",
+		);
+
+		expect(conf).not.toMatch(/cohesion/i);
+		expect(conf).not.toContain("io.github.brunofin.Cohesion");
+		expect(conf).toContain(
+			"windowrule = workspace name:0 silent, match:class brave-adaalabfemebkikihnkbonlockjjpbml-Default",
+		);
+		expect(conf).toContain(
+			"--app-id=adaalabfemebkikihnkbonlockjjpbml",
+		);
+		expect(conf).toContain("bind = $kbGoToWs, 0, exec, sh -lc");
+	});
+
+	it("keeps laptop app workspaces and keybindings aligned with the PC variant", () => {
+		const laptop = fs.readFileSync(
+			path.join(CONFIGS_CAELESTIA_DIR, "hypr-user-laptop.conf"),
+			"utf8",
+		);
+		const sharedMarkers = [
+			"bind = $kbEditor, exec, app2unit -- $editor",
+			"bind = $kbBrowser, exec, caelestia toggle brave-work",
+			"workspace = name:0, default:true, persistent:true",
+			"workspace = 1, default:true, persistent:true",
+			"workspace = 2, persistent:true",
+			"workspace = 3, persistent:true",
+			"workspace = 4, persistent:true",
+			"workspace = 5, default:true, persistent:true",
+			"windowrule = workspace 2 silent, match:class ^[Ss]team$",
+			"windowrule = workspace 4 silent, match:class vesktop",
+			"windowrule = workspace 5 silent, match:class (teams-for-linux|TelegramDesktop|org\\.telegram\\.desktop)",
+			"hyprctl dispatch exec \"[workspace 2 silent] app2unit -- steam\"",
+			"hyprctl dispatch exec \"[workspace 4 silent] app2unit -- vesktop\"",
+			"hyprshot -m output -m active",
+		];
+
+		for (const marker of sharedMarkers) {
+			expect(laptop).toContain(marker);
+		}
 	});
 
 	it("app-routed workspace binds use the launch-if-missing pattern", () => {

--- a/tests/configure_hyprland.test.js
+++ b/tests/configure_hyprland.test.js
@@ -10,7 +10,8 @@ function makeRecorder(scriptedReturns = {}) {
 	const calls = [];
 	const run = async (command, options = {}) => {
 		calls.push({ command, options });
-		if (Object.hasOwn(scriptedReturns, command)) return scriptedReturns[command];
+		if (Object.hasOwn(scriptedReturns, command))
+			return scriptedReturns[command];
 		// Default: succeed unless the test patched a specific command to fail.
 		return true;
 	};
@@ -118,7 +119,10 @@ describe("installCaelestia (slim 5.0.0 — Caelestia only, no Ocean overlay)", (
 		const cloneDir = path.join(tmpHome, ".local", "share", "caelestia");
 		fs.mkdirSync(path.join(cloneDir, ".git"), { recursive: true });
 		// install.fish is invoked unconditionally, so leave a placeholder file.
-		fs.writeFileSync(path.join(cloneDir, "install.fish"), "#!/usr/bin/env fish\n");
+		fs.writeFileSync(
+			path.join(cloneDir, "install.fish"),
+			"#!/usr/bin/env fish\n",
+		);
 		return cloneDir;
 	}
 
@@ -137,7 +141,9 @@ describe("installCaelestia (slim 5.0.0 — Caelestia only, no Ocean overlay)", (
 		expect(hyprlandInstallCommand.split(" ")).toContain("uwsm");
 		// Must clone Caelestia (no .git existed) — clone uses HTTPS.
 		expect(
-			commands.some((c) => c.startsWith("git clone") && c.includes("caelestia")),
+			commands.some(
+				(c) => c.startsWith("git clone") && c.includes("caelestia"),
+			),
 		).toBe(true);
 		// Must run install.fish via `fish ...`.
 		expect(commands.some((c) => c.startsWith("fish "))).toBe(true);
@@ -200,7 +206,8 @@ describe("installCaelestia (slim 5.0.0 — Caelestia only, no Ocean overlay)", (
 		// Recovery's leaf install command should have fired.
 		expect(
 			commands.some(
-				(c) => c === "paru -S --needed --noconfirm caelestia-cli caelestia-shell",
+				(c) =>
+					c === "paru -S --needed --noconfirm caelestia-cli caelestia-shell",
 			),
 		).toBe(true);
 	});
@@ -289,10 +296,7 @@ describe("installCaelestia (slim 5.0.0 — Caelestia only, no Ocean overlay)", (
 		const caelestiaHyprDir = path.join(caelestiaCloneDir, "hypr");
 		fs.mkdirSync(caelestiaHyprDir, { recursive: true });
 		fs.mkdirSync(path.join(tmpHome, ".config"), { recursive: true });
-		fs.symlinkSync(
-			caelestiaHyprDir,
-			path.join(tmpHome, ".config", "hypr"),
-		);
+		fs.symlinkSync(caelestiaHyprDir, path.join(tmpHome, ".config", "hypr"));
 
 		const { run } = makeRecorder();
 		const exists = async (cmd) => cmd === "fish" || cmd === "caelestia";
@@ -351,6 +355,46 @@ describe("installCaelestia (slim 5.0.0 — Caelestia only, no Ocean overlay)", (
 		);
 		const applyIndex = calls.indexOf(applyCall);
 		expect(applyIndex).toBeGreaterThan(installFishIndex);
+	});
+
+	it("requests the lockfix apply.sh exit code so failure modes stay distinct", async () => {
+		const { calls, run } = makeRecorder();
+		const exists = async (cmd) => cmd === "fish" || cmd === "caelestia";
+
+		await hyprland.installCaelestia({ home: tmpHome, run, exists });
+
+		const expectedScript = path.join(
+			tmpHome,
+			".local",
+			"share",
+			"caelestia-lockfix",
+			"apply.sh",
+		);
+		const applyCall = calls.find((c) => c.command === `bash ${expectedScript}`);
+		expect(applyCall?.options).toEqual({ check: false, returnExitCode: true });
+	});
+
+	it("warns specifically when lockfix auto-reverted because Caelestia shell did not restart", async () => {
+		const expectedScript = path.join(
+			tmpHome,
+			".local",
+			"share",
+			"caelestia-lockfix",
+			"apply.sh",
+		);
+		const { run } = makeRecorder({ [`bash ${expectedScript}`]: 2 });
+		const exists = async (cmd) => cmd === "fish" || cmd === "caelestia";
+		const messages = [];
+		const originalLog = console.log;
+		console.log = (...args) => messages.push(args.join(" "));
+		try {
+			await hyprland.installCaelestia({ home: tmpHome, run, exists });
+		} finally {
+			console.log = originalLog;
+		}
+
+		expect(messages.join("\n")).toMatch(/Caelestia shell did not restart/i);
+		expect(messages.join("\n")).toMatch(/check whether the shell is running/i);
 	});
 
 	it("preserves existing Caelestia shell.json settings while forcing 24-hour clock", async () => {
@@ -501,5 +545,25 @@ describe("promptDeviceType", () => {
 		expect(persisted.deviceType).toBe("pc");
 		expect(persisted.skillSources).toEqual(["https://example.com/foo.git"]);
 		expect(persisted.extra).toBe(42);
+	});
+
+	it("warns when replacing a malformed ~/.haoshoku.json while persisting deviceType", async () => {
+		fs.writeFileSync(configPath, "{ not valid json");
+		const messages = [];
+		const originalLog = console.log;
+		console.log = (...args) => messages.push(args.join(" "));
+		try {
+			await hyprland.promptDeviceType({
+				configPath,
+				promptFn: buildPromptFn({ device: "laptop" }),
+			});
+		} finally {
+			console.log = originalLog;
+		}
+
+		expect(JSON.parse(fs.readFileSync(configPath, "utf8")).deviceType).toBe(
+			"laptop",
+		);
+		expect(messages.join("\n")).toMatch(/Malformed .*\.haoshoku\.json/i);
 	});
 });

--- a/tests/configure_lockfix.test.js
+++ b/tests/configure_lockfix.test.js
@@ -390,13 +390,36 @@ describe("seeded configs/caelestia-lockfix/ (in-tree static files)", () => {
 		).toBe(true);
 	});
 
-	it("exits non-zero after auto-reverting when Caelestia shell does not restart", () => {
+	it("keeps patch-apply failures on exit code 1", () => {
 		const applySh = fs.readFileSync(
 			path.join(CONFIGS_LOCKFIX_DIR, "apply.sh"),
 			"utf8",
 		);
 		expect(applySh).toMatch(
-			/shell did NOT come back[\s\S]*auto-reverting[\s\S]*exit 1/,
+			/A patch failed[\s\S]*Shell not restarted[\s\S]*exit 1/,
+		);
+	});
+
+	it("uses exit code 2 after auto-reverting when Caelestia shell does not restart", () => {
+		const applySh = fs.readFileSync(
+			path.join(CONFIGS_LOCKFIX_DIR, "apply.sh"),
+			"utf8",
+		);
+		expect(applySh).toMatch(
+			/shell did NOT come back[\s\S]*auto-reverting[\s\S]*exit 2/,
+		);
+	});
+
+	it("verifies the reverted Caelestia shell restart before claiming success", () => {
+		const applySh = fs.readFileSync(
+			path.join(CONFIGS_LOCKFIX_DIR, "apply.sh"),
+			"utf8",
+		);
+		expect([...applySh.matchAll(/pgrep -af 'qs -c caelestia'/g)]).toHaveLength(
+			2,
+		);
+		expect(applySh).toMatch(
+			/reverted; shell restarted with the originals[\s\S]*reverted; shell restart failed/i,
 		);
 	});
 });

--- a/tests/configure_lockfix.test.js
+++ b/tests/configure_lockfix.test.js
@@ -389,4 +389,14 @@ describe("seeded configs/caelestia-lockfix/ (in-tree static files)", () => {
 			),
 		).toBe(true);
 	});
+
+	it("exits non-zero after auto-reverting when Caelestia shell does not restart", () => {
+		const applySh = fs.readFileSync(
+			path.join(CONFIGS_LOCKFIX_DIR, "apply.sh"),
+			"utf8",
+		);
+		expect(applySh).toMatch(
+			/shell did NOT come back[\s\S]*auto-reverting[\s\S]*exit 1/,
+		);
+	});
 });

--- a/tests/configure_mimeapps.test.js
+++ b/tests/configure_mimeapps.test.js
@@ -28,12 +28,34 @@ afterEach(() => {
 });
 
 const FIXTURE_CONTENT = "[Default Applications]\ntext/plain=zed.desktop\n";
+const CLAUDE_HANDLER_DESKTOP = `[Desktop Entry]
+Name=Claude Code URL Handler
+Comment=Handle claude-cli:// deep links for Claude Code
+Exec=claude --handle-uri %u
+Type=Application
+NoDisplay=true
+MimeType=x-scheme-handler/claude-cli;
+`;
 
 /** Seed a mimeapps.list in the repo configs dir. */
 function seedRepoMimeapps() {
 	fs.writeFileSync(
 		path.join(tmpProjectRoot, "configs", "mimeapps", "mimeapps.list"),
 		FIXTURE_CONTENT,
+	);
+}
+
+function seedRepoDesktopHandlers() {
+	const applicationsDir = path.join(
+		tmpProjectRoot,
+		"configs",
+		"mimeapps",
+		"applications",
+	);
+	fs.mkdirSync(applicationsDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(applicationsDir, "claude-code-url-handler.desktop"),
+		CLAUDE_HANDLER_DESKTOP,
 	);
 }
 
@@ -119,6 +141,27 @@ describe("syncMimeappsConfig — deploys mimeapps.list to ~/.config/", () => {
 				"utf8",
 			),
 		).toBe(FIXTURE_CONTENT);
+	});
+
+	it("deploys managed .desktop handlers to ~/.local/share/applications/", async () => {
+		seedRepoMimeapps();
+		seedRepoDesktopHandlers();
+		await mimeapps.syncMimeappsConfig({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const handler = path.join(
+			tmpHome,
+			".local",
+			"share",
+			"applications",
+			"claude-code-url-handler.desktop",
+		);
+		expect(fs.existsSync(handler)).toBe(true);
+		expect(fs.readFileSync(handler, "utf8")).toContain(
+			"MimeType=x-scheme-handler/claude-cli;",
+		);
 	});
 });
 
@@ -269,5 +312,61 @@ describe("seeded configs/mimeapps/ (in-tree static config)", () => {
 			"utf8",
 		);
 		expect(content.length).toBeGreaterThan(0);
+	});
+
+	it("ships the Claude URL handler referenced by mimeapps.list", () => {
+		const content = fs.readFileSync(
+			path.join(CONFIGS_MIMEAPPS_DIR, "mimeapps.list"),
+			"utf8",
+		);
+		expect(content).toContain(
+			"x-scheme-handler/claude-cli=claude-code-url-handler.desktop",
+		);
+		expect(
+			fs.existsSync(
+				path.join(
+					CONFIGS_MIMEAPPS_DIR,
+					"applications",
+					"claude-code-url-handler.desktop",
+				),
+			),
+		).toBe(true);
+	});
+
+	it("covers every managed desktop entry with either a deployed handler or installed package", () => {
+		const mimeapps = fs.readFileSync(
+			path.join(CONFIGS_MIMEAPPS_DIR, "mimeapps.list"),
+			"utf8",
+		);
+		const packageLists = [
+			fs.readFileSync(
+				path.join(PROJECT_ROOT, "common", "paru_applist.txt"),
+				"utf8",
+			),
+			fs.readFileSync(
+				path.join(PROJECT_ROOT, "common", "flatpacks_arch.txt"),
+				"utf8",
+			),
+		].join("\n");
+		const deployedHandlersDir = path.join(CONFIGS_MIMEAPPS_DIR, "applications");
+		const deployedHandlers = fs.existsSync(deployedHandlersDir)
+			? new Set(fs.readdirSync(deployedHandlersDir))
+			: new Set();
+		const referenced = [
+			...new Set(
+				[...mimeapps.matchAll(/=([^\n;]+\.desktop)/g)].map((match) => match[1]),
+			),
+		];
+
+		const uncovered = referenced.filter((desktopFile) => {
+			if (deployedHandlers.has(desktopFile)) return false;
+			const packageName = desktopFile.replace(/\.desktop$/, "");
+			return !packageLists
+				.split("\n")
+				.map((line) => line.trim())
+				.includes(packageName);
+		});
+
+		expect(uncovered).toEqual([]);
 	});
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -149,4 +149,18 @@ describe("readConfiguredDeviceType", () => {
 		);
 		expect(readConfiguredDeviceType(tmpHome)).toBeNull();
 	});
+
+	it("warns when ~/.haoshoku.json contains malformed JSON", () => {
+		fs.writeFileSync(path.join(tmpHome, ".haoshoku.json"), "{ not valid json");
+		const messages = [];
+		const originalLog = console.log;
+		console.log = (...args) => messages.push(args.join(" "));
+		try {
+			expect(readConfiguredDeviceType(tmpHome)).toBeNull();
+		} finally {
+			console.log = originalLog;
+		}
+
+		expect(messages.join("\n")).toMatch(/Malformed .*\.haoshoku\.json/i);
+	});
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import {
 	commandExists,
+	readConfiguredDeviceType,
 	readDeviceType,
 	runCommand,
 	safeCopyFile,
@@ -112,5 +113,40 @@ describe("readDeviceType", () => {
 			JSON.stringify({ deviceType: "server" }),
 		);
 		expect(readDeviceType(tmpHome)).toBe("pc");
+	});
+});
+
+describe("readConfiguredDeviceType", () => {
+	let tmpHome;
+
+	beforeEach(() => {
+		tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-utils-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpHome, { recursive: true, force: true });
+	});
+
+	it("returns null when ~/.haoshoku.json is missing", () => {
+		expect(readConfiguredDeviceType(tmpHome)).toBeNull();
+	});
+
+	it("returns known explicit deviceType values", () => {
+		fs.writeFileSync(
+			path.join(tmpHome, ".haoshoku.json"),
+			JSON.stringify({ deviceType: "pc" }),
+		);
+		expect(readConfiguredDeviceType(tmpHome)).toBe("pc");
+	});
+
+	it("returns null for malformed or unknown deviceType values", () => {
+		fs.writeFileSync(path.join(tmpHome, ".haoshoku.json"), "{ not valid json");
+		expect(readConfiguredDeviceType(tmpHome)).toBeNull();
+
+		fs.writeFileSync(
+			path.join(tmpHome, ".haoshoku.json"),
+			JSON.stringify({ deviceType: "other" }),
+		);
+		expect(readConfiguredDeviceType(tmpHome)).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary
- Move audio sync after the Hyprland device-type prompt and stop falling back to PC-specific WirePlumber drop-ins when no explicit device type was captured.
- Harden WirePlumber pruning with Haoshoku-managed markers, old-content provenance checks, guarded filesystem reads/removes, and stale set-difference pruning so user-authored colliding filenames are left untouched.
- Keep portable PipeWire sync/backup behavior intact, strip live Haoshoku markers during WirePlumber backup, and make unset-device backup skip messaging explicit.
- Deploy the managed Claude URL desktop handler, add swayimg for image MIME defaults, and make lockfix distinguish patch failures from auto-revert/shell-restart failures.
- Align the laptop Caelestia variant with the PC app/workspace/keybinding behavior: Notion Brave PWA replaces Cohesion, Steam/Teams/Telegram/Vesktop/special workspace bindings match, and laptop keeps only monitor/GPU-specific differences.
- Remove the retired Cohesion Flatpak and document/test that laptop has no lossless WirePlumber hard-pin rule.
- Add regression coverage for the hardening surfaces and a patch-file whitespace attribute for stored unified diffs.

## Verification
- bun test tests/configure_audio.test.js: 35 pass, 0 fail
- bun test tests/configure_audio.test.js tests/cachyos.test.js tests/configure_lockfix.test.js tests/configure_hyprland.test.js tests/utils.test.js: 123 pass, 0 fail
- bun test: 179 pass, 0 fail
- bun run lint: Checked 45 files, no fixes applied
- bun audit --json: {}
- git diff --check: no output
- claude --handle-uri claude-cli://test: CLI parses the hidden handler flag and returns "Unknown deep link action", confirming it is not an unknown option
