### PR TITLE
feat: trial Vivaldi, ZapZap, and Cohesion

### DIFF
--- a/common/paru_applist.txt
+++ b/common/paru_applist.txt
@@ -1,6 +1,7 @@
 fish
 visual-studio-code-bin
 brave-bin
+cohesion-git
 floorp-bin
 zip
 kitty

--- a/configs/caelestia/cli.json
+++ b/configs/caelestia/cli.json
@@ -55,7 +55,7 @@
       "brave-work": {
         "enable": true,
         "match": [{"class": "brave-browser", "title": "Defi"}],
-        "command": ["brave", "--profile-directory=Profile 3"],
+        "command": ["brave", "--profile-directory=Profile 1"],
         "move": true
       }
     },

--- a/configs/caelestia/cli.json
+++ b/configs/caelestia/cli.json
@@ -43,19 +43,11 @@
         "command": ["foot", "-a", "btop", "-T", "btop", "env", "LC_ALL=C.UTF-8", "fish", "-C", "exec btop"]
       }
     },
-    "brave-personal": {
-      "brave-personal": {
+    "vivaldi": {
+      "vivaldi": {
         "enable": true,
-        "match": [{"class": "brave-browser", "title": "Flux"}],
-        "command": ["brave", "--profile-directory=Default"],
-        "move": true
-      }
-    },
-    "brave-work": {
-      "brave-work": {
-        "enable": true,
-        "match": [{"class": "brave-browser", "title": "Defi"}],
-        "command": ["brave", "--profile-directory=Profile 1"],
+        "match": [{"class": "vivaldi-stable"}],
+        "command": ["vivaldi"],
         "move": true
       }
     },

--- a/configs/caelestia/cli.json
+++ b/configs/caelestia/cli.json
@@ -13,10 +13,10 @@
         "command": ["signal-desktop"],
         "move": true
       },
-      "whatsapp-web": {
+      "zapzap": {
         "enable": true,
-        "match": [{"class": "brave-hnpfjngllnobngcgfapefoaidbinmjnm-Default"}],
-        "command": ["/opt/brave-bin/brave", "--profile-directory=Default", "--app-id=hnpfjngllnobngcgfapefoaidbinmjnm"],
+        "match": [{"class": "zapzap"}],
+        "command": ["flatpak", "run", "com.rtosta.zapzap"],
         "move": true
       }
     },

--- a/configs/caelestia/hypr-user-laptop.conf
+++ b/configs/caelestia/hypr-user-laptop.conf
@@ -27,7 +27,7 @@ unbind = $kbEditor
 bind = $kbEditor, exec, app2unit -- $editor
 
 # Super+W toggles the work-Brave special workspace (DEFI named window in the Defi
-# profile, which lives on disk as Brave's `Profile 3`).
+# profile, which lives on disk as Brave's `Profile 1`).
 unbind = $kbBrowser
 bind = $kbBrowser, exec, caelestia toggle brave-work
 
@@ -80,8 +80,10 @@ bind = Super, O, exec, caelestia toggle 1password
 
 # Brave profile windows each live in their own special workspace.
 windowrule = workspace special:brave-personal, match:class brave-browser, match:title Flux
+windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Flux
 bind = Super, B, exec, caelestia toggle brave-personal
 windowrule = workspace special:brave-work, match:class brave-browser, match:title Defi
+windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Defi
 
 # Claude Code in kitty with a distinct WM class so it doesn't catch other kitties.
 windowrule = workspace special:claude, match:class kitty-claude

--- a/configs/caelestia/hypr-user-laptop.conf
+++ b/configs/caelestia/hypr-user-laptop.conf
@@ -26,10 +26,9 @@ $editor = zeditor
 unbind = $kbEditor
 bind = $kbEditor, exec, app2unit -- $editor
 
-# Super+W toggles the work-Brave special workspace (DEFI named window in the Defi
-# profile, which lives on disk as Brave's `Profile 1`).
+# Super+W toggles a plain Vivaldi window while we trial it as the primary browser.
 unbind = $kbBrowser
-bind = $kbBrowser, exec, caelestia toggle brave-work
+bind = $kbBrowser, exec, caelestia toggle vivaldi
 
 # Messaging workspace. `persistent` keeps ws 5 alive when empty. `default:true`
 # mirrors the PC variant's default workspace set; without monitor pins, laptop
@@ -78,12 +77,10 @@ bind = Super+Shift, H, togglespecialworkspace, stash
 windowrule = workspace special:1password, match:class 1password
 bind = Super, O, exec, caelestia toggle 1password
 
-# Brave profile windows each live in their own special workspace.
-windowrule = workspace special:brave-personal, match:class brave-browser, match:title Flux
-windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Flux
-bind = Super, B, exec, caelestia toggle brave-personal
-windowrule = workspace special:brave-work, match:class brave-browser, match:title Defi
-windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Defi
+# Vivaldi browser trial as the only browser special workspace. Brave remains installed
+# and still backs the Notion / WhatsApp PWAs above.
+windowrule = workspace special:vivaldi, match:class vivaldi-stable
+windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class vivaldi-stable
 
 # Claude Code in kitty with a distinct WM class so it doesn't catch other kitties.
 windowrule = workspace special:claude, match:class kitty-claude

--- a/configs/caelestia/hypr-user-laptop.conf
+++ b/configs/caelestia/hypr-user-laptop.conf
@@ -50,17 +50,16 @@ windowrule = workspace special:music, match:class spotify|Spotify
 unbind = $kbMusic
 bind = $kbMusic, exec, caelestia toggle music
 
-# Notion workspace: named "0" so it sorts/displays as workspace 0 in the bar.
-# Notion runs as a Brave PWA (app-id adaalabfemebkikihnkbonlockjjpbml, Default profile).
-workspace = name:0, default:true, persistent:true
-windowrule = workspace name:0 silent, match:class brave-adaalabfemebkikihnkbonlockjjpbml-Default
+# Notion workspace: Cohesion on real workspace 10.
+workspace = 10, default:true, persistent:true
+windowrule = workspace 10 silent, match:class cohesion
 
-# Rebind Super+0 to go to the Notion workspace. If the Notion PWA has no window
-# yet, launch it into the named workspace.
+# Rebind Super+0 to go to workspace 10. If Cohesion has no window yet, launch it
+# into workspace 10.
 unbind = $kbGoToWs, 0
-bind = $kbGoToWs, 0, exec, sh -lc 'hyprctl dispatch workspace name:0; hyprctl clients -j | jq -e '\''any(.[]; .class == "brave-adaalabfemebkikihnkbonlockjjpbml-Default")'\'' >/dev/null || hyprctl dispatch exec "[workspace name:0 silent] app2unit -- /opt/brave-bin/brave --profile-directory=Default --app-id=adaalabfemebkikihnkbonlockjjpbml"'
+bind = $kbGoToWs, 0, exec, sh -lc 'hyprctl dispatch workspace 10; hyprctl clients -j | jq -e '\''any(.[]; .class == "cohesion")'\'' >/dev/null || hyprctl dispatch exec "[workspace 10 silent] app2unit -- cohesion"'
 unbind = $kbMoveWinToWs, 0
-bind = $kbMoveWinToWs, 0, exec, hyprctl dispatch movetoworkspace name:0
+bind = $kbMoveWinToWs, 0, exec, hyprctl dispatch movetoworkspace 10
 
 # Steam workspace. Catches the Steam launcher and its satellite windows (friends
 # list, downloads, etc.) which all share class=Steam.
@@ -78,7 +77,7 @@ windowrule = workspace special:1password, match:class 1password
 bind = Super, O, exec, caelestia toggle 1password
 
 # Vivaldi browser trial as the only browser special workspace. Brave remains installed
-# and still backs the Notion PWA above.
+# as a fallback while the Vivaldi/Cohesion setup is evaluated.
 windowrule = workspace special:vivaldi, match:class vivaldi-stable
 windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class vivaldi-stable
 

--- a/configs/caelestia/hypr-user-laptop.conf
+++ b/configs/caelestia/hypr-user-laptop.conf
@@ -40,10 +40,10 @@ windowrule = workspace 5 silent, match:class (teams-for-linux|TelegramDesktop|or
 unbind = $kbGoToWs, 5
 bind = $kbGoToWs, 5, exec, sh -lc 'hyprctl dispatch workspace 5; clients=$(hyprctl clients -j); printf "%s" "$clients" | jq -e '\''any(.[]; .class == "teams-for-linux")'\'' >/dev/null || hyprctl dispatch exec "[workspace 5 silent] app2unit -- teams-for-linux --gtk-version=3"; printf "%s" "$clients" | jq -e '\''any(.[]; .class == "TelegramDesktop" or .class == "org.telegram.desktop")'\'' >/dev/null || hyprctl dispatch exec "[workspace 5 silent] app2unit -- Telegram"'
 
-# Extend Caelestia's special:communication windowrule for Signal + the Brave
-# WhatsApp-Web PWA. The Brave PWA class is profile-specific.
+# Extend Caelestia's special:communication windowrule for Signal + ZapZap.
+# ZapZap's Flatpak desktop file declares StartupWMClass=zapzap.
 windowrule = workspace special:communication, match:class signal
-windowrule = workspace special:communication, match:class brave-hnpfjngllnobngcgfapefoaidbinmjnm-Default
+windowrule = workspace special:communication, match:class zapzap
 
 # Spotify uses Caelestia's music special workspace.
 windowrule = workspace special:music, match:class spotify|Spotify
@@ -78,7 +78,7 @@ windowrule = workspace special:1password, match:class 1password
 bind = Super, O, exec, caelestia toggle 1password
 
 # Vivaldi browser trial as the only browser special workspace. Brave remains installed
-# and still backs the Notion / WhatsApp PWAs above.
+# and still backs the Notion PWA above.
 windowrule = workspace special:vivaldi, match:class vivaldi-stable
 windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class vivaldi-stable
 

--- a/configs/caelestia/hypr-user-pc.conf
+++ b/configs/caelestia/hypr-user-pc.conf
@@ -37,12 +37,9 @@ $editor = zeditor
 unbind = $kbEditor
 bind = $kbEditor, exec, app2unit -- $editor
 
-# Super+W toggles the work-Brave special workspace (DEFI named window in the Defi
-# profile, which lives on disk as Brave's `Profile 1`). Caelestia's stock bind
-# launched plain $browser=brave; we override to the toggle instead. To launch a
-# fresh Brave window outside the toggle flow, use the app launcher or run `brave`.
+# Super+W toggles a plain Vivaldi window while we trial it as the primary browser.
 unbind = $kbBrowser
-bind = $kbBrowser, exec, caelestia toggle brave-work
+bind = $kbBrowser, exec, caelestia toggle vivaldi
 
 # Messaging workspace: ws 5 lives on the rightmost monitor (HDMI-A-1), and Teams /
 # Telegram always land there. `persistent` keeps ws 5 alive when empty, `default`
@@ -89,10 +86,8 @@ bind = $kbGoToWs, 0, exec, sh -lc 'hyprctl dispatch workspace name:0; hyprctl cl
 unbind = $kbMoveWinToWs, 0
 bind = $kbMoveWinToWs, 0, exec, hyprctl dispatch movetoworkspace name:0
 
-# ws 7 is no longer pinned: DEFI (work brave) moved to special:brave-work, summoned
-# via Super+W. ws 7 returns to being a free-roaming scratch slot. The
-# initial_title-based windowrule was unreliable (Brave's named-window title is
-# applied post-spawn) — replaced with cli.json's live-title selector.
+# ws 7 is no longer pinned; the browser trial lives in a special workspace summoned
+# via Super+W.
 
 # Steam workspace: ws 2 on DP-1 (primary), persistent. Catches the Steam launcher and
 # its satellite windows (friends list, downloads, etc.) which all share class=Steam.
@@ -120,25 +115,10 @@ bind = Super+Shift, H, togglespecialworkspace, stash
 windowrule = workspace special:1password, match:class 1password
 bind = Super, O, exec, caelestia toggle 1password
 
-# Brave Personal profile (xzat — Brave's `Default` directory) as a special workspace,
-# identified by the FLUX named window. We match in cli.json by class=brave-browser +
-# title=Flux because initial_title is generic ("New tab - Brave") and Brave applies
-# the named title post-spawn. The cli.json's move_client uses the *current* title,
-# so toggling moves FLUX to special:brave-personal correctly.
-#
-# Profile-dir mapping (Brave numbers profile dirs in creation order, so renames don't
-# update them — easy to misread): `Default` = xzat = personal; `Profile 1` = Defi = work.
-windowrule = workspace special:brave-personal, match:class brave-browser, match:title Flux
-# Caelestia's global opacity rule skips fullscreen windows. These named Brave
-# special workspaces should stay visually consistent even if one profile restores
-# a fullscreen state.
-windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Flux
-bind = Super, B, exec, caelestia toggle brave-personal
-
-# Brave Work profile (Defi) as its own special workspace. Super+W launches/toggles it;
-# the windowrule keeps externally opened Defi windows on the same special workspace.
-windowrule = workspace special:brave-work, match:class brave-browser, match:title Defi
-windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Defi
+# Vivaldi browser trial as the only browser special workspace. Brave remains installed
+# and still backs the Notion / WhatsApp PWAs above.
+windowrule = workspace special:vivaldi, match:class vivaldi-stable
+windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class vivaldi-stable
 
 # Claude Code special workspace: kitty with class=kitty-claude running `claude -r io`
 # from $HOME. The custom class lets us match this specific kitty instance without

--- a/configs/caelestia/hypr-user-pc.conf
+++ b/configs/caelestia/hypr-user-pc.conf
@@ -38,7 +38,7 @@ unbind = $kbEditor
 bind = $kbEditor, exec, app2unit -- $editor
 
 # Super+W toggles the work-Brave special workspace (DEFI named window in the Defi
-# profile, which lives on disk as Brave's `Profile 3`). Caelestia's stock bind
+# profile, which lives on disk as Brave's `Profile 1`). Caelestia's stock bind
 # launched plain $browser=brave; we override to the toggle instead. To launch a
 # fresh Brave window outside the toggle flow, use the app launcher or run `brave`.
 unbind = $kbBrowser
@@ -127,13 +127,18 @@ bind = Super, O, exec, caelestia toggle 1password
 # so toggling moves FLUX to special:brave-personal correctly.
 #
 # Profile-dir mapping (Brave numbers profile dirs in creation order, so renames don't
-# update them — easy to misread): `Default` = xzat = personal; `Profile 3` = Defi = work.
+# update them — easy to misread): `Default` = xzat = personal; `Profile 1` = Defi = work.
 windowrule = workspace special:brave-personal, match:class brave-browser, match:title Flux
+# Caelestia's global opacity rule skips fullscreen windows. These named Brave
+# special workspaces should stay visually consistent even if one profile restores
+# a fullscreen state.
+windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Flux
 bind = Super, B, exec, caelestia toggle brave-personal
 
 # Brave Work profile (Defi) as its own special workspace. Super+W launches/toggles it;
 # the windowrule keeps externally opened Defi windows on the same special workspace.
 windowrule = workspace special:brave-work, match:class brave-browser, match:title Defi
+windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Defi
 
 # Claude Code special workspace: kitty with class=kitty-claude running `claude -r io`
 # from $HOME. The custom class lets us match this specific kitty instance without

--- a/configs/caelestia/hypr-user-pc.conf
+++ b/configs/caelestia/hypr-user-pc.conf
@@ -65,25 +65,19 @@ windowrule = workspace special:music, match:class spotify|Spotify
 unbind = $kbMusic
 bind = $kbMusic, exec, caelestia toggle music
 
-# Notion workspace: named "0" so it sorts/displays as workspace 0 in the
-# bar, pinned to DP-2 (leftmost). Implemented as a *named* workspace because Hyprland's
-# numeric workspace IDs start at 1, and using a real low ID would conflict with
-# Caelestia's group-math (floor((ws-1)/10)*10 + N) in wsaction.fish.
-# Notion runs as a Brave PWA (app-id adaalabfemebkikihnkbonlockjjpbml, Default profile);
-# its Wayland class is brave-<app-id>-Default. (Previously the Cohesion Flatpak,
-# io.github.brunofin.Cohesion.)
-workspace = name:0, monitor:DP-2, default:true, persistent:true
-windowrule = workspace name:0 silent, match:class brave-adaalabfemebkikihnkbonlockjjpbml-Default
+# Notion workspace: Cohesion on real workspace 10, pinned to DP-2 (leftmost).
+# Cohesion's desktop file declares StartupWMClass=cohesion, matching the runtime
+# Hyprland class.
+workspace = 10, monitor:DP-2, default:true, persistent:true
+windowrule = workspace 10 silent, match:class cohesion
 
-# Rebind Super+0 to go to the Notion workspace (was: $wsaction workspace 10, the
-# group-relative "slot 10" which we don't use). If the Notion PWA has no window yet,
-# launch it into the named workspace. Same for Super+Alt+0 for moving a
-# window to it. Direct hyprctl dispatch bypasses wsaction.fish since named workspaces
-# don't participate in the group-math system.
+# Rebind Super+0 to go to workspace 10. If Cohesion has no window yet, launch it
+# into workspace 10. Same for Super+Alt+0 for moving a window there. Direct hyprctl
+# dispatch bypasses wsaction.fish to keep Super+0 stable regardless of workspace group.
 unbind = $kbGoToWs, 0
-bind = $kbGoToWs, 0, exec, sh -lc 'hyprctl dispatch workspace name:0; hyprctl clients -j | jq -e '\''any(.[]; .class == "brave-adaalabfemebkikihnkbonlockjjpbml-Default")'\'' >/dev/null || hyprctl dispatch exec "[workspace name:0 silent] app2unit -- /opt/brave-bin/brave --profile-directory=Default --app-id=adaalabfemebkikihnkbonlockjjpbml"'
+bind = $kbGoToWs, 0, exec, sh -lc 'hyprctl dispatch workspace 10; hyprctl clients -j | jq -e '\''any(.[]; .class == "cohesion")'\'' >/dev/null || hyprctl dispatch exec "[workspace 10 silent] app2unit -- cohesion"'
 unbind = $kbMoveWinToWs, 0
-bind = $kbMoveWinToWs, 0, exec, hyprctl dispatch movetoworkspace name:0
+bind = $kbMoveWinToWs, 0, exec, hyprctl dispatch movetoworkspace 10
 
 # ws 7 is no longer pinned; the browser trial lives in a special workspace summoned
 # via Super+W.
@@ -115,7 +109,7 @@ windowrule = workspace special:1password, match:class 1password
 bind = Super, O, exec, caelestia toggle 1password
 
 # Vivaldi browser trial as the only browser special workspace. Brave remains installed
-# and still backs the Notion PWA above.
+# as a fallback while the Vivaldi/Cohesion setup is evaluated.
 windowrule = workspace special:vivaldi, match:class vivaldi-stable
 windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class vivaldi-stable
 

--- a/configs/caelestia/hypr-user-pc.conf
+++ b/configs/caelestia/hypr-user-pc.conf
@@ -51,13 +51,12 @@ windowrule = workspace 5 silent, match:class (teams-for-linux|TelegramDesktop|or
 unbind = $kbGoToWs, 5
 bind = $kbGoToWs, 5, exec, sh -lc 'hyprctl dispatch workspace 5; clients=$(hyprctl clients -j); printf "%s" "$clients" | jq -e '\''any(.[]; .class == "teams-for-linux")'\'' >/dev/null || hyprctl dispatch exec "[workspace 5 silent] app2unit -- teams-for-linux --gtk-version=3"; printf "%s" "$clients" | jq -e '\''any(.[]; .class == "TelegramDesktop" or .class == "org.telegram.desktop")'\'' >/dev/null || hyprctl dispatch exec "[workspace 5 silent] app2unit -- Telegram"'
 
-# Extend Caelestia's communication-workspace catcher to include Signal and the Brave
-# WhatsApp-Web PWA. The upstream rule (rules.conf:39) only matches discord|equibop|
+# Extend Caelestia's communication-workspace catcher to include Signal and ZapZap.
+# The upstream rule (rules.conf:39) only matches discord|equibop|
 # vesktop|whatsapp; Hyprland evaluates windowrules additively, so these layers just
-# add more class matches. The Brave class is profile-specific (-Default suffix) — if
-# you reinstall the PWA under a different profile, update the regex below.
+# add more class matches. ZapZap's Flatpak desktop file declares StartupWMClass=zapzap.
 windowrule = workspace special:communication, match:class signal
-windowrule = workspace special:communication, match:class brave-hnpfjngllnobngcgfapefoaidbinmjnm-Default
+windowrule = workspace special:communication, match:class zapzap
 
 # Spotify uses Caelestia's music special workspace. Keep a lowercase class rule
 # because the Arch desktop file advertises StartupWMClass=spotify, while upstream
@@ -71,8 +70,8 @@ bind = $kbMusic, exec, caelestia toggle music
 # numeric workspace IDs start at 1, and using a real low ID would conflict with
 # Caelestia's group-math (floor((ws-1)/10)*10 + N) in wsaction.fish.
 # Notion runs as a Brave PWA (app-id adaalabfemebkikihnkbonlockjjpbml, Default profile);
-# its Wayland class is brave-<app-id>-Default — same scheme as the WhatsApp-Web PWA
-# in cli.json. (Previously the Cohesion Flatpak, io.github.brunofin.Cohesion.)
+# its Wayland class is brave-<app-id>-Default. (Previously the Cohesion Flatpak,
+# io.github.brunofin.Cohesion.)
 workspace = name:0, monitor:DP-2, default:true, persistent:true
 windowrule = workspace name:0 silent, match:class brave-adaalabfemebkikihnkbonlockjjpbml-Default
 
@@ -116,7 +115,7 @@ windowrule = workspace special:1password, match:class 1password
 bind = Super, O, exec, caelestia toggle 1password
 
 # Vivaldi browser trial as the only browser special workspace. Brave remains installed
-# and still backs the Notion / WhatsApp PWAs above.
+# and still backs the Notion PWA above.
 windowrule = workspace special:vivaldi, match:class vivaldi-stable
 windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class vivaldi-stable
 

--- a/tests/cachyos.test.js
+++ b/tests/cachyos.test.js
@@ -188,6 +188,18 @@ describe("AUR package list", () => {
       .filter((l) => l && !l.startsWith("#"));
     expect(pkgs).toContain("swayimg");
   });
+
+  it("includes cohesion-git for the Notion desktop client", () => {
+    const list = fs.readFileSync(
+      path.join(PROJECT_ROOT, "common", "paru_applist.txt"),
+      "utf8",
+    );
+    const pkgs = list
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith("#"));
+    expect(pkgs).toContain("cohesion-git");
+  });
 });
 
 describe("custom fish assets shipped by haoshoku", () => {

--- a/tests/configure_caelestia_prefs.test.js
+++ b/tests/configure_caelestia_prefs.test.js
@@ -371,8 +371,7 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 			expect.arrayContaining([
 				"communication",
 				"1password",
-				"brave-personal",
-				"brave-work",
+				"vivaldi",
 				"claude",
 				"music",
 			]),
@@ -418,18 +417,14 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 			command: ["spotify"],
 			move: true,
 		});
-		expect(toggles["brave-personal"]["brave-personal"]).toMatchObject({
+		expect(toggles.vivaldi.vivaldi).toMatchObject({
 			enable: true,
-			match: [{ class: "brave-browser", title: "Flux" }],
-			command: ["brave", "--profile-directory=Default"],
+			match: [{ class: "vivaldi-stable" }],
+			command: ["vivaldi"],
 			move: true,
 		});
-		expect(toggles["brave-work"]["brave-work"]).toMatchObject({
-			enable: true,
-			match: [{ class: "brave-browser", title: "Defi" }],
-			command: ["brave", "--profile-directory=Profile 1"],
-			move: true,
-		});
+		expect(toggles).not.toHaveProperty("brave-personal");
+		expect(toggles).not.toHaveProperty("brave-work");
 	});
 
 	it("launches sysmon btop with a UTF-8 locale override", () => {
@@ -513,7 +508,7 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 		);
 		const sharedMarkers = [
 			"bind = $kbEditor, exec, app2unit -- $editor",
-			"bind = $kbBrowser, exec, caelestia toggle brave-work",
+			"bind = $kbBrowser, exec, caelestia toggle vivaldi",
 			"workspace = name:0, default:true, persistent:true",
 			"workspace = 1, default:true, persistent:true",
 			"workspace = 2, persistent:true",
@@ -582,15 +577,18 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 			);
 			expect(conf).toContain("bind = $kbMusic, exec, caelestia toggle music");
 			expect(conf).toContain(
-				"windowrule = workspace special:brave-personal, match:class brave-browser, match:title Flux",
+				"windowrule = workspace special:vivaldi, match:class vivaldi-stable",
 			);
 			expect(conf).toContain(
-				"windowrule = workspace special:brave-work, match:class brave-browser, match:title Defi",
+				"bind = $kbBrowser, exec, caelestia toggle vivaldi",
 			);
+			expect(conf).not.toContain("bind = Super, B, exec, caelestia toggle brave-personal");
+			expect(conf).not.toContain("windowrule = workspace special:brave-personal");
+			expect(conf).not.toContain("windowrule = workspace special:brave-work");
 		}
 	});
 
-	it("keeps named Brave special windows translucent even when fullscreen", () => {
+	it("keeps the Vivaldi special window translucent even when fullscreen", () => {
 		for (const file of ["hypr-user-pc.conf", "hypr-user-laptop.conf"]) {
 			const conf = fs.readFileSync(
 				path.join(CONFIGS_CAELESTIA_DIR, file),
@@ -598,10 +596,7 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 			);
 
 			expect(conf).toContain(
-				"windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Flux",
-			);
-			expect(conf).toContain(
-				"windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Defi",
+				"windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class vivaldi-stable",
 			);
 		}
 	});

--- a/tests/configure_caelestia_prefs.test.js
+++ b/tests/configure_caelestia_prefs.test.js
@@ -427,7 +427,7 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 		expect(toggles["brave-work"]["brave-work"]).toMatchObject({
 			enable: true,
 			match: [{ class: "brave-browser", title: "Defi" }],
-			command: ["brave", "--profile-directory=Profile 3"],
+			command: ["brave", "--profile-directory=Profile 1"],
 			move: true,
 		});
 	});
@@ -586,6 +586,22 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 			);
 			expect(conf).toContain(
 				"windowrule = workspace special:brave-work, match:class brave-browser, match:title Defi",
+			);
+		}
+	});
+
+	it("keeps named Brave special windows translucent even when fullscreen", () => {
+		for (const file of ["hypr-user-pc.conf", "hypr-user-laptop.conf"]) {
+			const conf = fs.readFileSync(
+				path.join(CONFIGS_CAELESTIA_DIR, file),
+				"utf8",
+			);
+
+			expect(conf).toContain(
+				"windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Flux",
+			);
+			expect(conf).toContain(
+				"windowrule = opacity $windowOpacity override $windowOpacity override $windowOpacity override, match:class brave-browser, match:title Defi",
 			);
 		}
 	});

--- a/tests/configure_caelestia_prefs.test.js
+++ b/tests/configure_caelestia_prefs.test.js
@@ -456,7 +456,7 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 			path.join(CONFIGS_CAELESTIA_DIR, "hypr-user-pc.conf"),
 			"utf8",
 		);
-		expect(conf).toMatch(/workspace\s*=\s*name:0\s*,\s*monitor:DP-2/);
+		expect(conf).toMatch(/workspace\s*=\s*10\s*,\s*monitor:DP-2/);
 		expect(conf).toMatch(/workspace\s*=\s*5\s*,\s*monitor:HDMI-A-1/);
 		expect(conf).toMatch(/workspace\s*=\s*4\s*,\s*monitor:HDMI-A-1/);
 		expect(conf).toMatch(/workspace\s*=\s*1\s*,\s*monitor:DP-1/);
@@ -476,26 +476,59 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 		expect(conf).not.toMatch(/nvidia-settings/);
 		expect(conf).not.toMatch(/\bvrr\b/);
 		// Workspaces should be persistent but NOT monitor-pinned
-		expect(conf).toMatch(/workspace\s*=\s*name:0/);
+		expect(conf).toMatch(/workspace\s*=\s*10/);
 		expect(conf).not.toMatch(/workspace\s*=\s*\d+\s*,\s*monitor:/);
-		expect(conf).not.toMatch(/workspace\s*=\s*name:0\s*,\s*monitor:/);
+		expect(conf).not.toMatch(/workspace\s*=\s*10\s*,\s*monitor:/);
 	});
 
-	it("uses the Notion Brave PWA on laptop instead of the retired Cohesion app", () => {
-		const conf = fs.readFileSync(
+	it("routes Notion through Cohesion on workspace 10", () => {
+		const pc = fs.readFileSync(
+			path.join(CONFIGS_CAELESTIA_DIR, "hypr-user-pc.conf"),
+			"utf8",
+		);
+		const laptop = fs.readFileSync(
 			path.join(CONFIGS_CAELESTIA_DIR, "hypr-user-laptop.conf"),
 			"utf8",
 		);
 
-		expect(conf).not.toMatch(/cohesion/i);
-		expect(conf).not.toContain("io.github.brunofin.Cohesion");
-		expect(conf).toContain(
-			"windowrule = workspace name:0 silent, match:class brave-adaalabfemebkikihnkbonlockjjpbml-Default",
+		expect(pc).toContain(
+			"workspace = 10, monitor:DP-2, default:true, persistent:true",
 		);
-		expect(conf).toContain(
-			"--app-id=adaalabfemebkikihnkbonlockjjpbml",
-		);
-		expect(conf).toContain("bind = $kbGoToWs, 0, exec, sh -lc");
+		expect(laptop).toContain("workspace = 10, default:true, persistent:true");
+
+		for (const conf of [pc, laptop]) {
+			expect(conf).toContain(
+				"windowrule = workspace 10 silent, match:class cohesion",
+			);
+			expect(conf).toContain("bind = $kbGoToWs, 0, exec, sh -lc");
+			expect(conf).toContain("hyprctl dispatch workspace 10");
+			expect(conf).toContain('any(.[]; .class == "cohesion")');
+			expect(conf).toContain(
+				'hyprctl dispatch exec "[workspace 10 silent] app2unit -- cohesion"',
+			);
+			expect(conf).toContain(
+				"bind = $kbMoveWinToWs, 0, exec, hyprctl dispatch movetoworkspace 10",
+			);
+			expect(conf).not.toContain("workspace = name:0");
+			expect(conf).not.toContain("brave-adaalabfemebkikihnkbonlockjjpbml-Default");
+			expect(conf).not.toContain("--app-id=adaalabfemebkikihnkbonlockjjpbml");
+		}
+	});
+
+	it("keeps the retired Cohesion Flatpak out of app routing", () => {
+		for (const file of ["hypr-user-pc.conf", "hypr-user-laptop.conf"]) {
+			const conf = fs.readFileSync(
+				path.join(CONFIGS_CAELESTIA_DIR, file),
+				"utf8",
+			);
+
+			expect(conf).not.toContain(
+				"windowrule = workspace 10 silent, match:class io.github.brunofin.Cohesion",
+			);
+			expect(conf).not.toContain(
+				"app2unit -- flatpak run io.github.brunofin.Cohesion",
+			);
+		}
 	});
 
 	it("keeps laptop app workspaces and keybindings aligned with the PC variant", () => {
@@ -506,7 +539,7 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 		const sharedMarkers = [
 			"bind = $kbEditor, exec, app2unit -- $editor",
 			"bind = $kbBrowser, exec, caelestia toggle vivaldi",
-			"workspace = name:0, default:true, persistent:true",
+			"workspace = 10, default:true, persistent:true",
 			"workspace = 1, default:true, persistent:true",
 			"workspace = 2, persistent:true",
 			"workspace = 3, persistent:true",

--- a/tests/configure_caelestia_prefs.test.js
+++ b/tests/configure_caelestia_prefs.test.js
@@ -390,16 +390,13 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 			command: ["signal-desktop"],
 			move: true,
 		});
-		expect(toggles.communication["whatsapp-web"]).toMatchObject({
+		expect(toggles.communication.zapzap).toMatchObject({
 			enable: true,
-			match: [{ class: "brave-hnpfjngllnobngcgfapefoaidbinmjnm-Default" }],
-			command: [
-				"/opt/brave-bin/brave",
-				"--profile-directory=Default",
-				"--app-id=hnpfjngllnobngcgfapefoaidbinmjnm",
-			],
+			match: [{ class: "zapzap" }],
+			command: ["flatpak", "run", "com.rtosta.zapzap"],
 			move: true,
 		});
+		expect(toggles.communication).not.toHaveProperty("whatsapp-web");
 		expect(toggles["1password"]["1password"]).toMatchObject({
 			enable: true,
 			match: [{ class: "1password" }],
@@ -567,8 +564,10 @@ describe("seeded configs/caelestia/ (in-tree static configs)", () => {
 				"windowrule = workspace special:communication, match:class signal",
 			);
 			expect(conf).toContain(
-				"windowrule = workspace special:communication, match:class brave-hnpfjngllnobngcgfapefoaidbinmjnm-Default",
+				"windowrule = workspace special:communication, match:class zapzap",
 			);
+			expect(conf).not.toContain("brave-hnpfjngllnobngcgfapefoaidbinmjnm-Default");
+			expect(conf).not.toContain("--app-id=hnpfjngllnobngcgfapefoaidbinmjnm");
 			expect(conf).toContain(
 				"windowrule = workspace special:1password, match:class 1password",
 			);


### PR DESCRIPTION
## Summary
- Route `$kbBrowser` / Super+W to `caelestia toggle vivaldi` with a plain `vivaldi` command and `vivaldi-stable` class match.
- Remove the Super+B personal Brave toggle plus the old Brave personal/work special-workspace routing.
- Replace the Brave WhatsApp Web PWA with the ZapZap Flatpak in the Caelestia communication toggle and Hyprland special-workspace rules.
- Replace the Notion Brave PWA with `cohesion-git`, routed by class `cohesion` on workspace 10 with Super+0 launch/switch behavior.
- Keep Brave installed as a fallback while Vivaldi, ZapZap, and Cohesion are trialed.
- Cover the Vivaldi toggle, removed Brave toggles, ZapZap migration, Cohesion workspace routing, and fullscreen opacity rule in regression tests.

## Test Plan
- [x] `bun test`
- [x] `bun run lint`
- [x] `git diff --check`
- [x] TDD red check: focused package/Caelestia tests failed before the Cohesion config patch
- [x] Live verification: `hyprctl reload config-only`
- [x] Live verification: `hyprctl configerrors`
- [x] Live readback: `$kbBrowser` points to `caelestia toggle vivaldi`, no Super+B Brave toggle remains, ZapZap uses `flatpak run com.rtosta.zapzap`, Cohesion uses workspace 10 / class `cohesion`, and `hyprctl getprop 'class:vivaldi-stable' opacity` returns `0.95`
