### PR TITLE
Robustness hardening: 50 review findings fixed across 10 clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -324,3 +324,6 @@ tasks/
 /superpowers/
 
 # End of https://www.toptal.com/developers/gitignore/api/python,node
+
+# Branch/session working notes (local-only)
+BRANCH-NOTES.md

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	}
+}

--- a/haoshoku.js
+++ b/haoshoku.js
@@ -4,7 +4,8 @@ import fs from "node:fs";
 import { Command } from "commander";
 import prompts from "prompts";
 import { getBanner, showBanner } from "./src/common/ui.js";
-import { log } from "./src/common/utils.js";
+import { detectOS, findActiveModeFlags } from "./src/common/cli_utils.js";
+import { log, promptUser } from "./src/common/utils.js";
 import {
   backupClaudeConfig,
   installSuperpowers,
@@ -57,33 +58,6 @@ program
   .description("Haoshoku: Color of the Supreme King. Dominate your setup.")
   .version("5.5.3")
   .addHelpText("before", getBanner());
-
-function detectOS() {
-  try {
-    const osRelease = fs.readFileSync("/etc/os-release", "utf-8");
-    const lines = osRelease.split("\n");
-    const info = {};
-    for (const line of lines) {
-      const [key, value] = line.split("=");
-      if (key && value) {
-        info[key] = value.replace(/"/g, "");
-      }
-    }
-
-    const id = info.ID ? info.ID.toLowerCase() : "";
-    const idLike = info.ID_LIKE ? info.ID_LIKE.toLowerCase() : "";
-
-    if (id.includes("cachyos") || idLike.includes("arch")) {
-      return "cachyos";
-    }
-    if (id.includes("debian") || idLike.includes("debian")) {
-      return "debian-server";
-    }
-  } catch (_e) {
-    // Ignore error if file doesn't exist
-  }
-  return null;
-}
 
 program
   .option("--os <type>", "Specify the target OS (cachyos, debian-server)")
@@ -147,7 +121,27 @@ program
     "Install Hyprland + upstream Caelestia rice (CachyOS/Arch only). Asks about your current DE and which device this is; persists the device answer to ~/.haoshoku.json for future per-host configs.",
   )
   .action(async (options) => {
+    try {
+      await runAction(options);
+    } catch (err) {
+      log.error(err.message);
+      log.dim(err.stack);
+      process.exit(1);
+    }
+  });
+
+async function runAction(options) {
     showBanner();
+
+    // Mutually-exclusive mode flags: pass exactly one. Previously the if/return
+    // chain silently ran only the first matching flag and ignored the rest.
+    const activeFlags = findActiveModeFlags(options);
+    if (activeFlags.length >= 2) {
+      log.error(
+        `--${activeFlags[0]} and --${activeFlags[1]} are mutually exclusive — pass exactly one mode flag`,
+      );
+      process.exit(2);
+    }
 
     if (options.claudeUpdate) {
       await updateClaudeConfig();
@@ -302,12 +296,17 @@ program
     }
 
     let osType = options.os;
+    // Track whether osType came from silent auto-detection (vs the --os flag or
+    // the interactive select prompt): a bare `haoshoku` must confirm before
+    // mutating the system.
+    let osAutoDetected = false;
 
     if (!osType) {
       const detected = detectOS();
       if (detected) {
         log.info(`Detected OS: ${detected}`);
         osType = detected;
+        osAutoDetected = true;
       } else {
         const response = await prompts({
           type: "select",
@@ -325,6 +324,19 @@ program
     if (!osType) {
       log.error("No OS selected. Exiting.");
       process.exit(1);
+    }
+
+    if (osAutoDetected) {
+      // Bare `haoshoku` would otherwise launch a system-mutating setup with
+      // zero confirmation. promptUser aborts the process on Ctrl+C.
+      const proceed = await promptUser(
+        `Detected ${osType} — run the full ${osType} setup now?`,
+        true,
+      );
+      if (!proceed) {
+        log.info("Setup cancelled. Exiting.");
+        return;
+      }
     }
 
     log.info(`Starting setup for: ${osType}`);
@@ -351,6 +363,6 @@ program
     if (syncResponse.syncSkills) {
       syncSkills({ update: false });
     }
-  });
+}
 
 program.parse(process.argv);

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -28,6 +28,64 @@ Examples:
 Non-interactive mode is intended for agent / CI use. The git-clean check
 is enforced in all modes — there is no --force flag by design.`;
 
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+/**
+ * Compute the next version string from the current version and a bump type.
+ * Pure function — throws on a malformed current/custom version instead of
+ * silently producing NaN.NaN.1 tags.
+ *
+ * @param {string} currentVersion - current semver, e.g. "5.5.3"
+ * @param {"patch"|"minor"|"major"|"custom"} bump - bump type
+ * @param {string} [explicitVersion] - required when bump === "custom"
+ * @returns {string} the next version
+ */
+export function computeNextVersion(currentVersion, bump, explicitVersion) {
+	if (bump === "custom") {
+		if (!SEMVER_RE.test(explicitVersion || "")) {
+			throw new Error(
+				`Invalid custom version: ${explicitVersion} (expected x.y.z)`,
+			);
+		}
+		return explicitVersion;
+	}
+
+	if (!SEMVER_RE.test(currentVersion || "")) {
+		throw new Error(
+			`Invalid current version: ${currentVersion} (expected x.y.z)`,
+		);
+	}
+
+	const [major, minor, patch] = currentVersion.split(".").map(Number);
+	switch (bump) {
+		case "patch":
+			return `${major}.${minor}.${patch + 1}`;
+		case "minor":
+			return `${major}.${minor + 1}.0`;
+		case "major":
+			return `${major + 1}.0.0`;
+		default:
+			throw new Error(`Invalid bump type: ${bump}`);
+	}
+}
+
+/**
+ * Replace the single `.version("...")` site in haoshoku.js content with the
+ * new version. Throws if no match is found so a silent no-op cannot ship a
+ * release with a stale --version.
+ *
+ * @param {string} content - haoshoku.js source
+ * @param {string} newVersion - version to write
+ * @returns {string} updated content
+ */
+export function applyVersionBump(content, newVersion) {
+	const updated = content.replace(/\.version\(".*"\)/, `.version("${newVersion}")`);
+	if (updated === content) {
+		throw new Error("version pattern not found in haoshoku.js");
+	}
+	return updated;
+}
+
 /** Parse argv into { bump, version, yes, help } — no external dep. */
 function parseArgs(argv) {
 	const args = { bump: null, version: null, yes: false, help: false };
@@ -65,8 +123,15 @@ async function runCommand(command, args, options = {}) {
 async function isGitClean() {
 	const proc = spawn(["git", "status", "--porcelain"], {
 		stdout: "pipe",
+		stderr: "pipe",
 	});
 	const output = await new Response(proc.stdout).text();
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) {
+		throw new Error(
+			`git status failed (exit ${exitCode}) — cannot verify clean tree`,
+		);
+	}
 	return output.trim() === "";
 }
 
@@ -111,69 +176,71 @@ async function main() {
 
 	log.info(`Current version: ${chalk.bold(currentVersion)}`);
 
+	// Ctrl+C / Esc at any prompt cancels the release cleanly (exit 0).
+	const onCancel = () => {
+		log.info("Release cancelled.");
+		process.exit(0);
+	};
+
 	// 3. Determine bump (flag or prompt)
 	let bump = args.bump;
 	if (!bump) {
-		const response = await prompts({
-			type: "select",
-			name: "bump",
-			message: "Select version bump",
-			choices: [
-				{ title: "Patch", value: "patch" },
-				{ title: "Minor", value: "minor" },
-				{ title: "Major", value: "major" },
-				{ title: "Custom", value: "custom" },
-			],
-		});
+		const response = await prompts(
+			{
+				type: "select",
+				name: "bump",
+				message: "Select version bump",
+				choices: [
+					{ title: "Patch", value: "patch" },
+					{ title: "Minor", value: "minor" },
+					{ title: "Major", value: "major" },
+					{ title: "Custom", value: "custom" },
+				],
+			},
+			{ onCancel },
+		);
 		if (!response.bump) process.exit(0);
 		bump = response.bump;
 	} else {
 		log.info(`Bump: ${chalk.bold(bump)}${args.version ? ` (${args.version})` : ""}`);
 	}
 
-	let newVersion;
-	if (bump === "custom") {
-		if (args.version) {
-			newVersion = args.version;
-		} else {
-			const custom = await prompts({
+	let customVersion = args.version;
+	if (bump === "custom" && !customVersion) {
+		const custom = await prompts(
+			{
 				type: "text",
 				name: "version",
 				message: "Enter version number",
 				validate: (value) =>
-					/^\d+\.\d+\.\d+/.test(value) ? true : "Invalid version format (x.y.z)",
-			});
-			newVersion = custom.version;
-		}
-		if (!/^\d+\.\d+\.\d+$/.test(newVersion || "")) {
-			log.error(`Invalid --version value: ${newVersion} (expected x.y.z)`);
-			process.exit(2);
-		}
-	} else {
-		const [major, minor, patch] = currentVersion.split(".").map(Number);
-		switch (bump) {
-			case "patch":
-				newVersion = `${major}.${minor}.${patch + 1}`;
-				break;
-			case "minor":
-				newVersion = `${major}.${minor + 1}.0`;
-				break;
-			case "major":
-				newVersion = `${major + 1}.0.0`;
-				break;
-		}
+					/^\d+\.\d+\.\d+$/.test(value) ? true : "Invalid version format (x.y.z)",
+			},
+			{ onCancel },
+		);
+		customVersion = custom.version;
+	}
+
+	let newVersion;
+	try {
+		newVersion = computeNextVersion(currentVersion, bump, customVersion);
+	} catch (error) {
+		log.error(error.message);
+		process.exit(2);
 	}
 
 	if (!newVersion) process.exit(0);
 
 	// 4. Confirm (skip with --yes)
 	if (!args.yes) {
-		const confirm = await prompts({
-			type: "confirm",
-			name: "value",
-			message: `Ready to release v${newVersion}?`,
-			initial: true,
-		});
+		const confirm = await prompts(
+			{
+				type: "confirm",
+				name: "value",
+				message: `Ready to release v${newVersion}?`,
+				initial: true,
+			},
+			{ onCancel },
+		);
 		if (!confirm.value) process.exit(0);
 	} else {
 		log.info(`Releasing v${newVersion} (--yes)`);
@@ -185,14 +252,11 @@ async function main() {
 		writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
 		log.success(`Updated package.json to v${newVersion}`);
 
-		// Update haoshoku.js
+		// Update haoshoku.js — applyVersionBump throws if no .version() site
+		// matches, so a silent no-op cannot ship a stale --version.
 		const cliPath = resolve(process.cwd(), "haoshoku.js");
-		let cliContent = readFileSync(cliPath, "utf-8");
-		cliContent = cliContent.replace(
-			/\.version\(".*"\)/,
-			`.version("${newVersion}")`,
-		);
-		writeFileSync(cliPath, cliContent);
+		const cliContent = readFileSync(cliPath, "utf-8");
+		writeFileSync(cliPath, applyVersionBump(cliContent, newVersion));
 		log.success(`Updated haoshoku.js to v${newVersion}`);
 
 		// 5. Git operations
@@ -226,4 +290,10 @@ async function main() {
 	}
 }
 
-main().catch(console.error);
+// Guard so importing this module (e.g. for unit tests) doesn't run a release.
+if (import.meta.main) {
+	main().catch((err) => {
+		log.error(err?.message ?? String(err));
+		process.exit(1);
+	});
+}

--- a/src/common/cli_utils.js
+++ b/src/common/cli_utils.js
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+
+/**
+ * Full set of mutually-exclusive mode flags (commander camelCase keys).
+ *
+ * `--os` is intentionally NOT in this set: it selects the OS target for the
+ * default full-setup path and composes with that path rather than picking a
+ * one-shot mode. Every other documented `.option(...)` flag is a mode flag and
+ * exactly one may be passed per invocation.
+ */
+export const MODE_FLAGS = [
+	"claude",
+	"claudeBackup",
+	"claudeUpdate",
+	"skills",
+	"skillsUpdate",
+	"skillsList",
+	"superpowers",
+	"zed",
+	"zedBackup",
+	"zedTheme",
+	"caelestiaPrefs",
+	"caelestiaPrefsBackup",
+	"sddmPosthook",
+	"audio",
+	"audioBackup",
+	"mimeapps",
+	"mimeappsBackup",
+	"lockfix",
+	"lockfixBackup",
+	"kdeTheme",
+	"kdeThemeBackup",
+	"kdeGlass",
+	"hyprland",
+];
+
+/**
+ * Detect the target OS family from an os-release file.
+ *
+ * Arch family (CachyOS, vanilla Arch, and Arch derivatives) all map to
+ * "cachyos"; Debian family (Debian, Ubuntu, and derivatives) maps to
+ * "debian-server". Vanilla Arch publishes `ID=arch` with NO `ID_LIKE`, so we
+ * must match `id` itself — checking only `ID_LIKE` left vanilla Arch undetected
+ * and made `--hyprland` refuse to run.
+ *
+ * @param {string} [osReleasePath="/etc/os-release"] path to an os-release file
+ * @returns {"cachyos" | "debian-server" | null}
+ */
+export function detectOS(osReleasePath = "/etc/os-release") {
+	try {
+		const osRelease = fs.readFileSync(osReleasePath, "utf-8");
+		const lines = osRelease.split("\n");
+		const info = {};
+		for (const line of lines) {
+			const [key, value] = line.split("=");
+			if (key && value) {
+				info[key] = value.replace(/"/g, "");
+			}
+		}
+
+		const id = info.ID ? info.ID.toLowerCase() : "";
+		const idLike = info.ID_LIKE ? info.ID_LIKE.toLowerCase() : "";
+
+		if (id.includes("cachyos") || id.includes("arch") || idLike.includes("arch")) {
+			return "cachyos";
+		}
+		if (id.includes("debian") || idLike.includes("debian")) {
+			return "debian-server";
+		}
+	} catch (_e) {
+		// Ignore error if file doesn't exist or is unreadable.
+	}
+	return null;
+}
+
+/**
+ * Given commander's parsed options object, return the names of every set
+ * mode flag (truthy value). Used to reject invocations that pass 2+ mutually
+ * exclusive mode flags instead of silently honoring only the first.
+ *
+ * @param {Record<string, unknown>} options commander options object
+ * @returns {string[]} set mode-flag names, in MODE_FLAGS order
+ */
+export function findActiveModeFlags(options = {}) {
+	return MODE_FLAGS.filter((flag) => options[flag]);
+}

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -22,12 +22,21 @@ export async function runCommand(command, options = { check: true }) {
 		);
 
 	try {
-		const proc = spawn(useShell ? ["sh", "-c", command] : command.split(" "), {
-			cwd: options.cwd,
-			stdin: "inherit",
-			stdout: "inherit",
-			stderr: "inherit",
-		});
+		// Shell-routed commands run under bash with pipefail so a failing early
+		// pipeline stage (e.g. `curl bad-url | sh`) surfaces as a non-zero exit
+		// instead of POSIX sh's last-stage-only status, which masks broken
+		// installs as success. Plain commands keep argv-splitting.
+		const proc = spawn(
+			useShell
+				? ["bash", "-c", `set -o pipefail; ${command}`]
+				: command.split(" "),
+			{
+				cwd: options.cwd,
+				stdin: "inherit",
+				stdout: "inherit",
+				stderr: "inherit",
+			},
+		);
 
 		const exitCode = await proc.exited;
 
@@ -47,12 +56,10 @@ export async function runCommand(command, options = { check: true }) {
 }
 
 export async function commandExists(command) {
-	const proc = spawn(["which", command], {
-		stdout: "ignore",
-		stderr: "ignore",
-	});
-	const exitCode = await proc.exited;
-	return exitCode === 0;
+	// Bun.which resolves PATH in-process — no external `which` binary (absent
+	// from Arch's base set) and no spawn that could throw. Kept async because
+	// callers await it.
+	return Bun.which(command) !== null;
 }
 
 /** Drain stale stdin data (e.g. terminal escape sequences from subprocesses). */
@@ -69,38 +76,84 @@ async function drainStdin() {
 	});
 }
 
-/** Prompt user for yes/no confirmation. */
-export async function promptUser(message, initial = false) {
-	await drainStdin();
-	const { default: prompts } = await import("prompts");
-	const response = await prompts({
-		type: "confirm",
-		name: "value",
-		message: message,
-		initial: initial,
-	});
+/**
+ * Prompt user for yes/no confirmation.
+ *
+ * On Ctrl+C the underlying `prompts` lib resolves `{}` (value `undefined`),
+ * which a naive caller reads as "No" and barrels on with a destructive setup.
+ * Instead we pass an `onCancel` handler that warns and aborts the process with
+ * exit code 130 (SIGINT convention).
+ *
+ * `opts.promptFn` / `opts.exit` are injectable for tests; when `promptFn` is
+ * injected we skip drainStdin so tests don't wait the 300ms drain.
+ */
+export async function promptUser(message, initial = false, opts = {}) {
+	const exit = opts.exit ?? process.exit;
+	const onCancel = () => {
+		log.warning("Cancelled — aborting.");
+		exit(130);
+	};
+
+	let promptFn = opts.promptFn;
+	if (!promptFn) {
+		await drainStdin();
+		promptFn = (await import("prompts")).default;
+	}
+
+	const response = await promptFn(
+		{
+			type: "confirm",
+			name: "value",
+			message: message,
+			initial: initial,
+		},
+		{ onCancel },
+	);
 	return response.value;
 }
 
 /**
  * Copy `src` to `dest`, preserving any existing `dest` as `${dest}.bak` first.
- * Single rolling backup — re-running overwrites the previous .bak.
+ *
+ * Content-aware: if `dest` already exists with bytes identical to `src` it's a
+ * no-op — no copy, no .bak touched, returns false. This protects the user's
+ * ORIGINAL backup: without the check, a second run would copy the
+ * already-synced file over `.bak`, destroying the pristine original captured on
+ * the first run. Otherwise back up an existing `dest` to `${dest}.bak`, copy
+ * `src` over `dest`, and return true.
+ *
+ * @returns {boolean} true if `dest` was written, false if it was already in sync
  */
 export function safeCopyFile(src, dest) {
 	if (fs.existsSync(dest)) {
+		if (fs.readFileSync(dest).equals(fs.readFileSync(src))) {
+			log.dim(`${path.basename(dest)} unchanged — skipping`);
+			return false;
+		}
 		fs.copyFileSync(dest, `${dest}.bak`);
 		log.info(`Backed up existing ${path.basename(dest)} to ${dest}.bak`);
 	}
 	fs.copyFileSync(src, dest);
+	return true;
 }
 
-/** Recursively copy a directory tree (files and nested dirs). */
+/** Recursively copy a directory tree (files, nested dirs, and symlinks). */
 export function copyDirRecursive(src, dest) {
 	fs.mkdirSync(dest, { recursive: true });
 	for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
 		const srcPath = path.join(src, entry.name);
 		const destPath = path.join(dest, entry.name);
-		if (entry.isDirectory()) {
+		if (entry.isSymbolicLink()) {
+			// Recreate the link verbatim instead of dereferencing it: a symlink
+			// to a directory would crash copyFileSync with EISDIR, and a file
+			// symlink would be silently dereferenced. lstat (not existsSync,
+			// which follows links and misses dangling ones) clears any existing
+			// dest first so re-runs don't throw EEXIST.
+			if (fs.lstatSync(destPath, { throwIfNoEntry: false })) {
+				fs.unlinkSync(destPath);
+			}
+			fs.symlinkSync(fs.readlinkSync(srcPath), destPath);
+		} else if (entry.isDirectory()) {
 			copyDirRecursive(srcPath, destPath);
 		} else {
 			fs.copyFileSync(srcPath, destPath);

--- a/src/helpers/configure_caelestia_prefs.js
+++ b/src/helpers/configure_caelestia_prefs.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
-import { log, readDeviceType } from "../common/utils.js";
+import { log, readDeviceType, safeCopyFile } from "../common/utils.js";
 
 const HOME_DEFAULT = homedir();
 const PROJECT_ROOT_DEFAULT = path.resolve(__dirname, "..", "..");
@@ -50,7 +50,9 @@ export async function syncCaelestiaPrefs(opts = {}) {
   const variantSrc = path.join(caelestiaBackupDir, variantFilename(deviceType));
   const hyprUserDest = path.join(caelestiaConfigDir, "hypr-user.conf");
   if (fs.existsSync(variantSrc)) {
-    fs.copyFileSync(variantSrc, hyprUserDest);
+    // safeCopyFile preserves the user-owned live hypr-user.conf (their monitor
+    // config) as .bak instead of letting it vanish under the repo variant.
+    safeCopyFile(variantSrc, hyprUserDest);
     log.info(`Synced ${variantFilename(deviceType)} → hypr-user.conf`);
   } else {
     log.warning(
@@ -62,7 +64,7 @@ export async function syncCaelestiaPrefs(opts = {}) {
   const cliSrc = path.join(caelestiaBackupDir, "cli.json");
   const cliDest = path.join(caelestiaConfigDir, "cli.json");
   if (fs.existsSync(cliSrc)) {
-    fs.copyFileSync(cliSrc, cliDest);
+    safeCopyFile(cliSrc, cliDest);
     log.info("Synced cli.json");
   }
 
@@ -93,8 +95,24 @@ export async function backupCaelestiaPrefs(opts = {}) {
   const hyprUserSrc = path.join(caelestiaConfigDir, "hypr-user.conf");
   const variantDest = path.join(caelestiaBackupDir, variantFilename(deviceType));
   if (fs.existsSync(hyprUserSrc)) {
-    fs.copyFileSync(hyprUserSrc, variantDest);
-    log.info(`Backed up hypr-user.conf → ${variantFilename(deviceType)}`);
+    // installCaelestia pre-creates an EMPTY hypr-user.conf placeholder before
+    // first boot. Backing that empty file up over a curated repo variant would
+    // silently wipe the host's real monitor config. Guard: when the live file
+    // is empty/whitespace-only but the repo already holds a non-empty variant,
+    // skip it — the repo copy is the source of truth.
+    const liveIsBlank =
+      fs.readFileSync(hyprUserSrc, "utf8").trim().length === 0;
+    const repoHasContent =
+      fs.existsSync(variantDest) &&
+      fs.readFileSync(variantDest, "utf8").length > 0;
+    if (liveIsBlank && repoHasContent) {
+      log.warning(
+        `Live hypr-user.conf at ${hyprUserSrc} is empty (pre-boot placeholder) — keeping curated ${variantFilename(deviceType)} instead of clobbering it.`,
+      );
+    } else {
+      fs.copyFileSync(hyprUserSrc, variantDest);
+      log.info(`Backed up hypr-user.conf → ${variantFilename(deviceType)}`);
+    }
   }
 
   // Portable: cli.json

--- a/src/helpers/configure_claude.js
+++ b/src/helpers/configure_claude.js
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
-import { log, runCommand, copyDirRecursive } from "../common/utils.js";
+import {
+  copyDirRecursive,
+  log,
+  runCommand,
+  safeCopyFile,
+} from "../common/utils.js";
 
 const HOME = homedir();
 const CLAUDE_CONFIG_DIR = path.join(HOME, ".claude");
@@ -34,14 +39,9 @@ function claudeFilePath(src, home = HOME) {
   return path.join(home, ".claude", src);
 }
 
-/** Check if a command exists in PATH. */
+/** Check if a command exists in PATH (Bun.which — no external `which` binary). */
 function commandExists(cmd) {
-  try {
-    const result = Bun.spawnSync(["which", cmd]);
-    return result.exitCode === 0;
-  } catch {
-    return false;
-  }
+  return Bun.which(cmd) !== null;
 }
 
 /** Install Claude Code CLI if not already present. */
@@ -89,7 +89,10 @@ export async function syncClaudeConfig(options = {}) {
     const srcPath = path.join(srcDir, file.src);
     const destPath = claudeFilePath(file.src, claudeHome);
     if (fs.existsSync(srcPath)) {
-      fs.copyFileSync(srcPath, destPath);
+      // safeCopyFile preserves a differing live file (e.g. settings.json, which
+      // Claude Code and --superpowers mutate at runtime) as ${dest}.bak before
+      // overwriting. Identical content is a no-op so re-runs don't churn .bak.
+      safeCopyFile(srcPath, destPath);
       log.info(`Copied ${file.src}`);
     } else {
       log.warning(`Missing ${file.src} in source bundle (${srcPath}) — skipped`);
@@ -100,6 +103,11 @@ export async function syncClaudeConfig(options = {}) {
     const src = path.join(srcDir, dir);
     const dest = path.join(claudeDir, dir);
     if (fs.existsSync(src)) {
+      // MANAGED_DIRS are fully owned by haoshoku ("replaced on sync"), but
+      // copyDirRecursive only merges — so a convention deleted from the bundle
+      // would linger in ~/.claude/ forever. Wipe the dest first so the live
+      // tree exactly mirrors the bundle.
+      fs.rmSync(dest, { recursive: true, force: true });
       copyDirRecursive(src, dest);
       log.info(`Synced ${dir}/`);
     } else {
@@ -152,7 +160,15 @@ export async function installSuperpowers(settingsPath = SETTINGS_PATH) {
   }
 
   log.info("Enabling Superpowers plugin in ~/.claude/settings.json...");
-  const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+  let settings;
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+  } catch (err) {
+    log.error(
+      `settings.json is not valid JSON (${err?.message ?? err}) — fix it or re-run haoshoku --claude`,
+    );
+    return;
+  }
   settings.enabledPlugins ??= {};
 
   if (settings.enabledPlugins[SUPERPOWERS_PLUGIN_ID] === true) {

--- a/src/helpers/configure_git.js
+++ b/src/helpers/configure_git.js
@@ -1,18 +1,73 @@
 import fs from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
-import prompts from "prompts";
-import { log, promptUser, runCommand } from "../common/utils.js";
+import promptsLib from "prompts";
+import {
+	log,
+	promptUser as promptUserDefault,
+	safeCopyFile,
+} from "../common/utils.js";
 
 const HOME = homedir();
-const SSH_DIR = path.join(HOME, ".ssh");
 
-async function createProfile(profileType) {
+/**
+ * Default runner: spawns an argv array via Bun.spawn and returns its exit code.
+ *
+ * Using an argv array (not a shell string) is the whole point — the free-form
+ * email from the prompt is passed as a discrete argument to ssh-keygen, so a
+ * quote or `;` in the email can never break out into shell interpretation.
+ *
+ * @param {string[]} argv
+ * @returns {Promise<{ exitCode: number }>}
+ */
+async function defaultRunner(argv) {
+	const proc = Bun.spawn(argv, {
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+	const exitCode = await proc.exited;
+	return { exitCode };
+}
+
+/** Default ssh-agent bootstrap (no-op-able in tests via opts.startAgent). */
+async function startSshAgent() {
+	try {
+		const agentProc = Bun.spawn(["ssh-agent", "-s"]);
+		const output = await new Response(agentProc.stdout).text();
+		const match = output.match(/SSH_AUTH_SOCK=([^;]+);/);
+		if (match) {
+			process.env.SSH_AUTH_SOCK = match[1];
+		}
+		const pidMatch = output.match(/SSH_AGENT_PID=([^;]+);/);
+		if (pidMatch) {
+			process.env.SSH_AGENT_PID = pidMatch[1];
+		}
+	} catch (_e) {
+		log.warning("Could not start ssh-agent.");
+	}
+}
+
+/**
+ * Create a single Git profile (email/name/signing key) under `${home}/${profileType}`.
+ *
+ * Key generation is guarded two ways:
+ *   - If the key already exists, generation is SKIPPED (ssh-keygen would
+ *     otherwise hang on an interactive "Overwrite (y/n)?" prompt) but the
+ *     signing config is still emitted — we keep using the existing key.
+ *   - If generation runs and FAILS, the profile gitconfig is written WITHOUT
+ *     any signing directives. Emitting `gpgsign = true` + a `signingkey` that
+ *     doesn't exist would make every future commit in that gitdir fail to sign.
+ *
+ * @param {string} profileType e.g. "personal" | "work"
+ * @param {{ home: string, sshDir: string, promptFn: Function, runner: Function }} ctx
+ */
+async function createProfile(profileType, { home, sshDir, promptFn, runner }) {
 	log.info(`--- Setting up ${profileType} Git profile ---`);
-	const profileDir = path.join(HOME, profileType);
+	const profileDir = path.join(home, profileType);
 	fs.mkdirSync(profileDir, { recursive: true });
 
-	const response = await prompts([
+	const response = await promptFn([
 		{
 			type: "text",
 			name: "email",
@@ -35,28 +90,64 @@ async function createProfile(profileType) {
 		return;
 	}
 
-	const keyPath = path.join(SSH_DIR, `${profileType}_key`);
+	const keyPath = path.join(sshDir, `${profileType}_key`);
 	const gitConfigPath = path.join(profileDir, `.gitconfig.${profileType}`);
 
-	// Generate SSH Key
-	log.info(`Generating SSH key for ${profileType}...`);
-	await runCommand(
-		`ssh-keygen -t ed25519 -C "${response.email}" -f ${keyPath} -N "" -q`,
-	);
+	// `signingOk` decides whether we emit the SSH-signing directives. It stays
+	// true when we reuse an existing key or generate one successfully, and flips
+	// to false only when a fresh generation fails.
+	let signingOk = true;
 
-	// Add to Agent
-	log.info(`Adding ${profileType} SSH key to agent...`);
-	await runCommand(`ssh-add ${keyPath}`);
+	if (fs.existsSync(keyPath)) {
+		// Skip generation: ssh-keygen would otherwise stop on an interactive
+		// overwrite prompt and hang the whole setup. The existing key is reused.
+		log.info(
+			`SSH key ${keyPath} already exists — skipping generation, reusing it.`,
+		);
+	} else {
+		log.info(`Generating SSH key for ${profileType}...`);
+		// argv array, NOT a shell string — the email is a discrete argument so
+		// quotes/semicolons in it can never be interpreted by a shell.
+		const { exitCode } = await runner([
+			"ssh-keygen",
+			"-t",
+			"ed25519",
+			"-C",
+			response.email,
+			"-f",
+			keyPath,
+			"-N",
+			"",
+			"-q",
+		]);
+		if (exitCode !== 0) {
+			signingOk = false;
+			log.warning(
+				`ssh-keygen failed (exit ${exitCode}) for ${profileType} — writing gitconfig WITHOUT SSH signing so future commits aren't blocked by a missing key.`,
+			);
+		} else {
+			// Add to agent (best-effort; argv array, no shell).
+			log.info(`Adding ${profileType} SSH key to agent...`);
+			await runner(["ssh-add", keyPath]);
+		}
+	}
 
-	// Create Git Config
-	const gitConfigContent = `[user]
+	// Build the profile gitconfig. Signing directives are appended only when a
+	// usable key is present.
+	let gitConfigContent = `[user]
     email = ${response.email}
-    name = ${response.username}
-    signingkey = ${keyPath}
+    name = ${response.username}`;
+	if (signingOk) {
+		gitConfigContent += `
+    signingkey = ${keyPath}`;
+	}
+	gitConfigContent += `
 
 [github]
     user = "${response.githubUser}"
-
+`;
+	if (signingOk) {
+		gitConfigContent += `
 [commit]
     gpgsign = true
 
@@ -66,38 +157,58 @@ async function createProfile(profileType) {
 [core]
     sshCommand = "ssh -i ${keyPath}"
 `;
+	}
 
 	fs.writeFileSync(gitConfigPath, gitConfigContent);
 	log.info(`Created ${gitConfigPath}`);
 }
 
-export async function configureGit() {
-	log.info("Configuring Git...");
-	fs.mkdirSync(SSH_DIR, { mode: 0o700, recursive: true });
+/**
+ * Configure Git profiles + the global ~/.gitconfig includeIf routing.
+ *
+ * The global ~/.gitconfig is overwrite-safe: if a differing one already exists
+ * it's backed up to ~/.gitconfig.bak first; if the generated content is
+ * byte-identical to what's already there the write is skipped entirely (and no
+ * stale .bak is touched). Both behaviors come from utils.safeCopyFile.
+ *
+ * Every collaborator is injectable for tests (defaults preserve production
+ * behavior): `home`, `sshDir`, `promptFn` (the prompts() multi-question lib),
+ * `promptUser` (the yes/no confirm from utils — Ctrl+C aborts, handled there),
+ * `runner` (Bun.spawn argv wrapper), and `startAgent`.
+ *
+ * @param {{
+ *   home?: string,
+ *   sshDir?: string,
+ *   promptFn?: Function,
+ *   promptUser?: Function,
+ *   runner?: (argv: string[]) => Promise<{ exitCode: number }>,
+ *   startAgent?: () => Promise<void>,
+ * }} [opts]
+ */
+export async function configureGit(opts = {}) {
+	const {
+		home = HOME,
+		sshDir = path.join(home, ".ssh"),
+		promptFn = promptsLib,
+		promptUser = promptUserDefault,
+		runner = defaultRunner,
+		startAgent = startSshAgent,
+	} = opts;
 
-	// Start SSH Agent
-	try {
-		const agentProc = Bun.spawn(["ssh-agent", "-s"]);
-		const output = await new Response(agentProc.stdout).text();
-		const match = output.match(/SSH_AUTH_SOCK=([^;]+);/);
-		if (match) {
-			process.env.SSH_AUTH_SOCK = match[1];
-		}
-		const pidMatch = output.match(/SSH_AGENT_PID=([^;]+);/);
-		if (pidMatch) {
-			process.env.SSH_AGENT_PID = pidMatch[1];
-		}
-	} catch (_e) {
-		log.warning("Could not start ssh-agent.");
-	}
+	log.info("Configuring Git...");
+	fs.mkdirSync(sshDir, { mode: 0o700, recursive: true });
+
+	await startAgent();
+
+	const ctx = { home, sshDir, promptFn, runner };
 
 	let workProfileCreated = false;
 	if (await promptUser("Do you want to create a work Git profile?", true)) {
-		await createProfile("work");
+		await createProfile("work", ctx);
 		workProfileCreated = true;
 	}
 
-	await createProfile("personal");
+	await createProfile("personal", ctx);
 
 	// Global Config
 	let globalConfigContent = `[includeIf "gitdir:~/personal/"]
@@ -110,10 +221,31 @@ export async function configureGit() {
 `;
 	}
 
-	const globalGitConfigPath = path.join(HOME, ".gitconfig");
-	fs.writeFileSync(globalGitConfigPath, globalConfigContent);
+	const globalGitConfigPath = path.join(home, ".gitconfig");
 
-	log.info(`Created global git config at ${globalGitConfigPath}`);
+	// safeCopyFile is content-aware: identical content → no write, no .bak;
+	// differing content → back up the user's existing ~/.gitconfig to
+	// ~/.gitconfig.bak, then write ours. Stage the generated content in a
+	// throwaway temp file so we can route the overwrite through that helper
+	// (staged outside the home tree so it never pollutes ~/.ssh).
+	const stagePath = path.join(
+		fs.mkdtempSync(path.join(tmpdir(), "haoshoku-gitcfg-")),
+		"gitconfig",
+	);
+	fs.writeFileSync(stagePath, globalConfigContent);
+	try {
+		const wrote = safeCopyFile(stagePath, globalGitConfigPath);
+		if (wrote) {
+			log.info(`Created global git config at ${globalGitConfigPath}`);
+		} else {
+			log.info(
+				`Global git config at ${globalGitConfigPath} already up to date — left untouched.`,
+			);
+		}
+	} finally {
+		fs.rmSync(path.dirname(stagePath), { recursive: true, force: true });
+	}
+
 	log.warning(
 		"ACTION REQUIRED: Copy the contents of the .pub files in ~/.ssh and add them to your GitHub accounts.",
 	);

--- a/src/helpers/configure_hyprland.js
+++ b/src/helpers/configure_hyprland.js
@@ -136,7 +136,19 @@ export function configureCaelestiaShell({ home = HOME } = {}) {
 	let shellConfig = {};
 
 	if (fs.existsSync(shellConfigPath)) {
-		shellConfig = JSON.parse(fs.readFileSync(shellConfigPath, "utf8"));
+		try {
+			shellConfig = JSON.parse(fs.readFileSync(shellConfigPath, "utf8"));
+		} catch (err) {
+			// A malformed user-owned shell.json would crash the whole
+			// installCaelestia run. Preserve it as .bak (so the user can recover
+			// hand edits) and continue from {} so we still write valid config.
+			const backupPath = `${shellConfigPath}.bak`;
+			fs.renameSync(shellConfigPath, backupPath);
+			log.warning(
+				`Malformed Caelestia shell.json at ${shellConfigPath} (${err?.message ?? err}) — moved to ${backupPath}; rewriting with defaults.`,
+			);
+			shellConfig = {};
+		}
 	}
 
 	shellConfig.services = {

--- a/src/helpers/configure_kde_theme.js
+++ b/src/helpers/configure_kde_theme.js
@@ -1,48 +1,104 @@
 import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
-import { copyDirRecursive, log, runCommand } from "../common/utils.js";
+import { copyDirRecursive, log, runCommand, safeCopyFile } from "../common/utils.js";
 
-const HOME = homedir();
-const PROJECT_ROOT = path.resolve(__dirname, "..", "..");
-const KDE_BUNDLE_DIR = path.join(PROJECT_ROOT, "configs", "kde");
+/**
+ * Recursively compare two directory trees for identical content.
+ *
+ * Returns true only if both paths exist, have the same set of entries at every
+ * level, and every corresponding file has byte-identical content. Symlinks are
+ * compared by their link target string, not the content they point to.
+ *
+ * @param {string} a  First directory path
+ * @param {string} b  Second directory path
+ * @returns {boolean}
+ */
+function dirsAreIdentical(a, b) {
+	if (!fs.existsSync(a) || !fs.existsSync(b)) return false;
 
-const COMPONENTS = [
-	{
-		name: "look-and-feel",
-		bundle: "look-and-feel/Ocean",
-		system: path.join(HOME, ".local", "share", "plasma", "look-and-feel", "Ocean"),
-	},
-	{
-		name: "kvantum",
-		bundle: "kvantum/Ocean",
-		system: path.join(HOME, ".config", "Kvantum", "Ocean"),
-	},
-	{
-		name: "aurorae",
-		bundle: "aurorae/Ocean",
-		system: path.join(HOME, ".local", "share", "aurorae", "themes", "Ocean"),
-	},
-	{
-		name: "desktoptheme",
-		bundle: "desktoptheme/Ocean",
-		system: path.join(HOME, ".local", "share", "plasma", "desktoptheme", "Ocean"),
-	},
-	{
-		name: "color-schemes",
-		bundle: "color-schemes/Ocean.colors",
-		system: path.join(HOME, ".local", "share", "color-schemes", "Ocean.colors"),
-	},
-];
+	const entriesA = fs.readdirSync(a).sort();
+	const entriesB = fs.readdirSync(b).sort();
+
+	if (entriesA.length !== entriesB.length) return false;
+	if (entriesA.some((name, i) => name !== entriesB[i])) return false;
+
+	for (const name of entriesA) {
+		const pathA = path.join(a, name);
+		const pathB = path.join(b, name);
+		const statA = fs.lstatSync(pathA);
+		const statB = fs.lstatSync(pathB);
+
+		if (statA.isSymbolicLink() !== statB.isSymbolicLink()) return false;
+		if (statA.isDirectory() !== statB.isDirectory()) return false;
+
+		if (statA.isSymbolicLink()) {
+			if (fs.readlinkSync(pathA) !== fs.readlinkSync(pathB)) return false;
+		} else if (statA.isDirectory()) {
+			if (!dirsAreIdentical(pathA, pathB)) return false;
+		} else {
+			if (!fs.readFileSync(pathA).equals(fs.readFileSync(pathB))) return false;
+		}
+	}
+
+	return true;
+}
+
+const HOME_DEFAULT = homedir();
+const PROJECT_ROOT_DEFAULT = path.resolve(__dirname, "..", "..");
+
+/**
+ * Resolve the KDE bundle dir and build the COMPONENTS list from injected home
+ * + projectRoot (defaults to real $HOME and the haoshoku project root).
+ *
+ * @param {{ home?: string, projectRoot?: string }} opts
+ */
+function resolveComponents({ home = HOME_DEFAULT, projectRoot = PROJECT_ROOT_DEFAULT } = {}) {
+	const kdeBundleDir = path.join(projectRoot, "configs", "kde");
+
+	return [
+		{
+			name: "look-and-feel",
+			bundle: "look-and-feel/Ocean",
+			system: path.join(home, ".local", "share", "plasma", "look-and-feel", "Ocean"),
+		},
+		{
+			name: "kvantum",
+			bundle: "kvantum/Ocean",
+			system: path.join(home, ".config", "Kvantum", "Ocean"),
+		},
+		{
+			name: "aurorae",
+			bundle: "aurorae/Ocean",
+			system: path.join(home, ".local", "share", "aurorae", "themes", "Ocean"),
+		},
+		{
+			name: "desktoptheme",
+			bundle: "desktoptheme/Ocean",
+			system: path.join(home, ".local", "share", "plasma", "desktoptheme", "Ocean"),
+		},
+		{
+			name: "color-schemes",
+			bundle: "color-schemes/Ocean.colors",
+			system: path.join(home, ".local", "share", "color-schemes", "Ocean.colors"),
+		},
+	].map((comp) => ({
+		...comp,
+		bundlePath: path.join(kdeBundleDir, comp.bundle),
+	}));
+}
 
 /** Backup KDE Ocean theme from system to configs/kde/. */
-export async function backupKdeTheme() {
-	log.info("Backing up KDE Ocean theme...");
-	fs.mkdirSync(KDE_BUNDLE_DIR, { recursive: true });
+export async function backupKdeTheme(opts = {}) {
+	const { projectRoot = PROJECT_ROOT_DEFAULT } = opts;
+	const kdeBundleDir = path.join(projectRoot, "configs", "kde");
 
-	for (const comp of COMPONENTS) {
+	log.info("Backing up KDE Ocean theme...");
+	fs.mkdirSync(kdeBundleDir, { recursive: true });
+
+	for (const comp of resolveComponents(opts)) {
 		const systemPath = comp.system;
-		const bundlePath = path.join(KDE_BUNDLE_DIR, comp.bundle);
+		const bundlePath = comp.bundlePath;
 
 		if (!fs.existsSync(systemPath)) {
 			log.warning(`${comp.name}: not found at ${systemPath}, skipping`);
@@ -62,11 +118,11 @@ export async function backupKdeTheme() {
 }
 
 /** Deploy KDE Ocean theme from configs/kde/ to system directories. */
-export async function syncKdeTheme() {
+export async function syncKdeTheme(opts = {}) {
 	log.info("Syncing KDE Ocean theme...");
 
-	for (const comp of COMPONENTS) {
-		const bundlePath = path.join(KDE_BUNDLE_DIR, comp.bundle);
+	for (const comp of resolveComponents(opts)) {
+		const bundlePath = comp.bundlePath;
 		const systemPath = comp.system;
 
 		if (!fs.existsSync(bundlePath)) {
@@ -75,10 +131,28 @@ export async function syncKdeTheme() {
 		}
 
 		if (fs.statSync(bundlePath).isDirectory()) {
+			// Directory target: if a real dir exists at dest, rename it to dest.bak
+			// (rm a stale .bak first so the rename always succeeds).
+			// Content-aware guard: if dest already matches the bundle exactly,
+			// skip the backup+copy entirely so the original user .bak is preserved
+			// across repeated sync runs (second run must not overwrite .bak with
+			// the bundle content that was deployed on the first run).
+			if (fs.existsSync(systemPath)) {
+				if (dirsAreIdentical(systemPath, bundlePath)) {
+					log.dim(`${comp.name} dir unchanged — skipping`);
+					continue;
+				}
+				const bakPath = `${systemPath}.bak`;
+				if (fs.existsSync(bakPath)) {
+					fs.rmSync(bakPath, { recursive: true, force: true });
+				}
+				fs.renameSync(systemPath, bakPath);
+				log.info(`Backed up existing ${comp.name} dir to ${bakPath}`);
+			}
 			copyDirRecursive(bundlePath, systemPath);
 		} else {
 			fs.mkdirSync(path.dirname(systemPath), { recursive: true });
-			fs.copyFileSync(bundlePath, systemPath);
+			safeCopyFile(bundlePath, systemPath);
 		}
 		log.info(`Synced ${comp.name}`);
 	}
@@ -87,8 +161,8 @@ export async function syncKdeTheme() {
 }
 
 /** Deploy theme and activate (used by OS setup scripts). */
-export async function configureKdeTheme() {
-	await syncKdeTheme();
+export async function configureKdeTheme(opts = {}) {
+	await syncKdeTheme(opts);
 	log.info("Activating KDE Ocean theme...");
 	await runCommand("plasma-apply-lookandfeel -a Ocean");
 	await runCommand("kvantummanager --set Ocean");

--- a/src/helpers/configure_mimeapps.js
+++ b/src/helpers/configure_mimeapps.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
-import { log } from "../common/utils.js";
+import { log, safeCopyFile } from "../common/utils.js";
 
 const HOME_DEFAULT = homedir();
 const PROJECT_ROOT_DEFAULT = path.resolve(__dirname, "..", "..");
@@ -63,7 +63,7 @@ export async function syncMimeappsConfig(opts = {}) {
   }
 
   fs.mkdirSync(liveDir, { recursive: true });
-  fs.copyFileSync(repoFile, liveFile);
+  safeCopyFile(repoFile, liveFile);
   syncDesktopHandlers(repoApplicationsDir, liveApplicationsDir);
   log.success("mimeapps.list synced to ~/.config/");
 }

--- a/src/helpers/configure_zed.js
+++ b/src/helpers/configure_zed.js
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
-import { log } from "../common/utils.js";
+import { log, safeCopyFile } from "../common/utils.js";
 
 const HOME = homedir();
 const ZED_CONFIG_DIR = path.join(HOME, ".config", "zed");
@@ -12,53 +12,252 @@ const ZED_BACKUP_DIR = path.join(CONFIGS_DIR, "zed");
 
 const SENSITIVE_KEYS = ["ssh_connections"];
 
-/** Strip single-line comments from JSONC content. */
+// Any object key whose name matches this is a credential and must never land
+// in the public repo backup. Kept deliberately broad — a false positive (a
+// stripped non-secret) is a cosmetic loss in a backup; a false negative is a
+// leaked secret.
+const SENSITIVE_KEY_RE =
+  /token|secret|passw|api[-_]?key|apikey|access[-_]?key|bearer|credential|private[-_]?key/i;
+
+/**
+ * Tolerant JSONC → JSON strip. Zed writes `//` line comments, `/* *​/` block
+ * comments, inline comments after values, and trailing commas — none of which
+ * `JSON.parse` accepts. We walk the characters tracking in-string state (so a
+ * `//` or `/*` inside a string literal, e.g. a URL, is preserved) and honoring
+ * backslash escapes, drop both comment forms, and strip trailing commas that
+ * precede a `}` or `]`.
+ *
+ * The trailing-comma strip is done inside the same character walk rather than a
+ * post-hoc global regex: a regex would also rewrite `,}` / `,]` that appears
+ * *inside a string value* (data, not syntax), silently corrupting it. We buffer
+ * a structural comma (and any following whitespace) and only emit it once we
+ * know the next significant character is not a closing brace/bracket; if it is,
+ * the buffered comma is dropped.
+ */
 function stripJsonComments(jsonc) {
-  return jsonc
-    .split("\n")
-    .filter((line) => !line.trim().startsWith("//"))
-    .join("\n");
+  let out = "";
+  let inString = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  let escaped = false;
+  // Holds a structural comma awaiting a lookahead decision, plus any whitespace
+  // seen after it. Empty string means no comma is currently buffered.
+  let pendingComma = "";
+
+  // Flush a buffered comma (with its trailing whitespace) to the output. Called
+  // when the next significant char proves the comma was NOT trailing.
+  const flushComma = () => {
+    out += pendingComma;
+    pendingComma = "";
+  };
+
+  for (let i = 0; i < jsonc.length; i++) {
+    const ch = jsonc[i];
+    const next = jsonc[i + 1];
+
+    if (inLineComment) {
+      if (ch === "\n") {
+        inLineComment = false;
+        // A comment between a comma and `}`/`]` does not make the comma
+        // non-trailing — accumulate the newline onto the pending comma if one
+        // is buffered, otherwise emit it directly.
+        if (pendingComma) {
+          pendingComma += ch;
+        } else {
+          out += ch;
+        }
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (ch === "*" && next === "/") {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+
+    if (inString) {
+      out += ch;
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    // Not in a string or comment.
+    if (ch === '"') {
+      flushComma();
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      inLineComment = true;
+      i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      inBlockComment = true;
+      i++;
+      continue;
+    }
+
+    if (pendingComma) {
+      // Deciding the fate of a buffered comma.
+      if (ch === "}" || ch === "]") {
+        // Trailing comma: drop it, keep the buffered whitespace, then emit the
+        // closing bracket.
+        out += pendingComma.slice(1);
+        pendingComma = "";
+        out += ch;
+      } else if (/\s/.test(ch)) {
+        // Whitespace after the comma — keep buffering until we see the next
+        // significant character.
+        pendingComma += ch;
+      } else {
+        // Real value follows: the comma was a separator, not trailing.
+        flushComma();
+        out += ch;
+      }
+      continue;
+    }
+
+    if (ch === ",") {
+      // Buffer this comma pending a lookahead decision.
+      pendingComma = ",";
+      continue;
+    }
+
+    out += ch;
+  }
+
+  // A comma buffered at EOF (e.g. trailing comma with no closing token) is
+  // emitted verbatim; JSON.parse will surface any genuine syntax error.
+  flushComma();
+  return out;
 }
 
-/** Remove sensitive keys from settings object. */
+/**
+ * Recursively strip sensitive entries from a settings value, collecting the
+ * JSON path of everything removed so the caller can report it.
+ *
+ * Rules:
+ *   - Top-level `ssh_connections` is removed (handled by the caller seed).
+ *   - Any object entry whose key matches SENSITIVE_KEY_RE is deleted.
+ *   - Any object entry keyed `env` whose value is a plain object is deleted
+ *     (MCP `context_servers` carry tokens in env blocks).
+ *   - Arrays and nested objects are walked; non-stripped values recurse.
+ *
+ * @param {*} value
+ * @param {string} pathPrefix - JSON path of `value` (for reporting)
+ * @param {string[]} stripped - accumulator of stripped paths
+ * @returns {*} the sanitized value
+ */
+function sanitizeValue(value, pathPrefix, stripped) {
+  if (Array.isArray(value)) {
+    return value.map((item, idx) =>
+      sanitizeValue(item, `${pathPrefix}[${idx}]`, stripped),
+    );
+  }
+  if (value && typeof value === "object") {
+    const result = {};
+    for (const [key, child] of Object.entries(value)) {
+      const childPath = pathPrefix ? `${pathPrefix}.${key}` : key;
+
+      if (SENSITIVE_KEY_RE.test(key)) {
+        stripped.push(childPath);
+        continue;
+      }
+      if (
+        key === "env" &&
+        child &&
+        typeof child === "object" &&
+        !Array.isArray(child)
+      ) {
+        stripped.push(childPath);
+        continue;
+      }
+
+      result[key] = sanitizeValue(child, childPath, stripped);
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
+ * Remove sensitive keys from a settings object: the top-level
+ * `ssh_connections` block plus any nested credential-shaped key at any depth.
+ * Logs each stripped path so the user can see what was withheld.
+ */
 function sanitizeSettings(settings) {
-  const sanitized = { ...settings };
+  const seeded = { ...settings };
   for (const key of SENSITIVE_KEYS) {
-    delete sanitized[key];
+    delete seeded[key];
+  }
+
+  const stripped = [];
+  const sanitized = sanitizeValue(seeded, "", stripped);
+  for (const strippedPath of stripped) {
+    log.warning(`stripped ${strippedPath} (sensitive)`);
   }
   return sanitized;
 }
 
-/** Backup Zed config from ~/.config/zed to configs/zed (sanitized). */
-export async function backupZedConfig() {
+/**
+ * Backup Zed config from ~/.config/zed to configs/zed (sanitized).
+ *
+ * @param {{ zedConfigDir?: string, backupDir?: string }} [opts]
+ */
+export async function backupZedConfig(opts = {}) {
+  const { zedConfigDir = ZED_CONFIG_DIR, backupDir = ZED_BACKUP_DIR } = opts;
+
   log.info("Backing up Zed config...");
 
-  fs.mkdirSync(ZED_BACKUP_DIR, { recursive: true });
-  fs.mkdirSync(path.join(ZED_BACKUP_DIR, "themes"), { recursive: true });
+  fs.mkdirSync(backupDir, { recursive: true });
+  fs.mkdirSync(path.join(backupDir, "themes"), { recursive: true });
 
-  const settingsPath = path.join(ZED_CONFIG_DIR, "settings.json");
+  const settingsPath = path.join(zedConfigDir, "settings.json");
   if (fs.existsSync(settingsPath)) {
     const raw = fs.readFileSync(settingsPath, "utf-8");
     const stripped = stripJsonComments(raw);
-    const settings = JSON.parse(stripped);
-    const sanitized = sanitizeSettings(settings);
-    const output = JSON.stringify(sanitized, null, 2);
-    fs.writeFileSync(path.join(ZED_BACKUP_DIR, "settings.json"), output);
-    log.info("Backed up settings.json (sanitized)");
+    // A malformed settings.json must not abort the whole backup — skip it and
+    // continue with keymap + themes.
+    let settings;
+    try {
+      settings = JSON.parse(stripped);
+    } catch (err) {
+      settings = null;
+      log.error(
+        `Could not parse ${settingsPath} (${err.message}) — skipping settings.json backup (check for unterminated strings or invalid JSON).`,
+      );
+    }
+    if (settings !== null) {
+      const sanitized = sanitizeSettings(settings);
+      const output = JSON.stringify(sanitized, null, 2);
+      fs.writeFileSync(path.join(backupDir, "settings.json"), output);
+      log.info("Backed up settings.json (sanitized)");
+    }
   }
 
-  const keymapPath = path.join(ZED_CONFIG_DIR, "keymap.json");
+  const keymapPath = path.join(zedConfigDir, "keymap.json");
   if (fs.existsSync(keymapPath)) {
-    fs.copyFileSync(keymapPath, path.join(ZED_BACKUP_DIR, "keymap.json"));
+    fs.copyFileSync(keymapPath, path.join(backupDir, "keymap.json"));
     log.info("Backed up keymap.json");
   }
 
-  const themesDir = path.join(ZED_CONFIG_DIR, "themes");
+  const themesDir = path.join(zedConfigDir, "themes");
   if (fs.existsSync(themesDir)) {
     const themes = fs.readdirSync(themesDir);
     for (const theme of themes) {
       const src = path.join(themesDir, theme);
-      const dest = path.join(ZED_BACKUP_DIR, "themes", theme);
+      const dest = path.join(backupDir, "themes", theme);
       fs.copyFileSync(src, dest);
       log.info(`Backed up themes/${theme}`);
     }
@@ -67,19 +266,27 @@ export async function backupZedConfig() {
   log.success("Zed config backed up to configs/zed/");
 }
 
-/** Deploy Zed themes from configs/zed/themes/ to ~/.config/zed/themes/. */
-export async function syncZedTheme() {
+/**
+ * Deploy Zed themes from configs/zed/themes/ to ~/.config/zed/themes/.
+ *
+ * @param {{ zedConfigDir?: string, backupDir?: string }} [opts]
+ */
+export async function syncZedTheme(opts = {}) {
+  const { zedConfigDir = ZED_CONFIG_DIR, backupDir = ZED_BACKUP_DIR } = opts;
+
   log.info("Syncing Zed theme...");
 
-  fs.mkdirSync(path.join(ZED_CONFIG_DIR, "themes"), { recursive: true });
+  fs.mkdirSync(path.join(zedConfigDir, "themes"), { recursive: true });
 
-  const themesDir = path.join(ZED_BACKUP_DIR, "themes");
+  const themesDir = path.join(backupDir, "themes");
   if (fs.existsSync(themesDir)) {
     const themes = fs.readdirSync(themesDir);
     for (const theme of themes) {
       const src = path.join(themesDir, theme);
-      const dest = path.join(ZED_CONFIG_DIR, "themes", theme);
-      fs.copyFileSync(src, dest);
+      const dest = path.join(zedConfigDir, "themes", theme);
+      // safeCopyFile backs up a diverging live theme to .bak first and skips
+      // identical content (so a second run never clobbers the original .bak).
+      safeCopyFile(src, dest);
       log.info(`Synced themes/${theme}`);
     }
   }
@@ -87,25 +294,33 @@ export async function syncZedTheme() {
   log.success("Zed theme synced to ~/.config/zed/themes/");
 }
 
-/** Deploy Zed config from configs/zed to ~/.config/zed. */
-export async function syncZedConfig() {
+/**
+ * Deploy Zed config from configs/zed to ~/.config/zed.
+ *
+ * @param {{ zedConfigDir?: string, backupDir?: string }} [opts]
+ */
+export async function syncZedConfig(opts = {}) {
+  const { zedConfigDir = ZED_CONFIG_DIR, backupDir = ZED_BACKUP_DIR } = opts;
+
   log.info("Syncing Zed config...");
 
-  fs.mkdirSync(ZED_CONFIG_DIR, { recursive: true });
+  fs.mkdirSync(zedConfigDir, { recursive: true });
 
-  const settingsPath = path.join(ZED_BACKUP_DIR, "settings.json");
+  const settingsPath = path.join(backupDir, "settings.json");
   if (fs.existsSync(settingsPath)) {
-    fs.copyFileSync(settingsPath, path.join(ZED_CONFIG_DIR, "settings.json"));
+    // safeCopyFile preserves the user's live settings.json as .bak before
+    // overwriting, and no-ops on identical content.
+    safeCopyFile(settingsPath, path.join(zedConfigDir, "settings.json"));
     log.info("Synced settings.json");
   }
 
-  const keymapPath = path.join(ZED_BACKUP_DIR, "keymap.json");
+  const keymapPath = path.join(backupDir, "keymap.json");
   if (fs.existsSync(keymapPath)) {
-    fs.copyFileSync(keymapPath, path.join(ZED_CONFIG_DIR, "keymap.json"));
+    safeCopyFile(keymapPath, path.join(zedConfigDir, "keymap.json"));
     log.info("Synced keymap.json");
   }
 
-  await syncZedTheme();
+  await syncZedTheme(opts);
 
   log.success("Zed config synced to ~/.config/zed/");
 }

--- a/src/helpers/configure_zed.js
+++ b/src/helpers/configure_zed.js
@@ -15,9 +15,41 @@ const SENSITIVE_KEYS = ["ssh_connections"];
 // Any object key whose name matches this is a credential and must never land
 // in the public repo backup. Kept deliberately broad — a false positive (a
 // stripped non-secret) is a cosmetic loss in a backup; a false negative is a
-// leaked secret.
+// leaked secret. `authorization` also covers Proxy-Authorization /
+// X-Authorization via substring match.
 const SENSITIVE_KEY_RE =
-  /token|secret|passw|api[-_]?key|apikey|access[-_]?key|bearer|credential|private[-_]?key/i;
+  /token|secret|passw|api[-_]?key|apikey|access[-_]?key|bearer|credential|private[-_]?key|authorization/i;
+
+// Inside a `headers` object the bar is lower: header names routinely carry
+// credentials under names the global regex misses (Cookie, X-Auth, …).
+const SENSITIVE_HEADER_RE =
+  /auth|token|cookie|session|secret|signature|credential|key/i;
+
+// A header VALUE that starts with an HTTP auth scheme is a credential no
+// matter what the header is called (e.g. `X-Custom: "Bearer <token>"`).
+const AUTH_SCHEME_VALUE_RE =
+  /^\s*(bearer|basic|digest|negotiate|oauth|token|dpop|hawk)\s+\S/i;
+
+/**
+ * Sanitize a `headers` object: drop any entry whose NAME looks credential-ish
+ * (SENSITIVE_HEADER_RE) or whose string VALUE starts with an HTTP auth scheme
+ * (AUTH_SCHEME_VALUE_RE). Benign headers (Content-Type, Accept, …) survive.
+ */
+function sanitizeHeaders(headers, pathPrefix, stripped) {
+  const result = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const headerPath = `${pathPrefix}.${name}`;
+    if (
+      SENSITIVE_HEADER_RE.test(name) ||
+      (typeof value === "string" && AUTH_SCHEME_VALUE_RE.test(value))
+    ) {
+      stripped.push(headerPath);
+      continue;
+    }
+    result[name] = value;
+  }
+  return result;
+}
 
 /**
  * Tolerant JSONC → JSON strip. Zed writes `//` line comments, `/* *​/` block
@@ -152,6 +184,8 @@ function stripJsonComments(jsonc) {
  *   - Any object entry whose key matches SENSITIVE_KEY_RE is deleted.
  *   - Any object entry keyed `env` whose value is a plain object is deleted
  *     (MCP `context_servers` carry tokens in env blocks).
+ *   - `headers` objects get per-entry scrutiny via sanitizeHeaders (credential
+ *     header names and auth-scheme values are dropped, benign headers kept).
  *   - Arrays and nested objects are walked; non-stripped values recurse.
  *
  * @param {*} value
@@ -181,6 +215,15 @@ function sanitizeValue(value, pathPrefix, stripped) {
         !Array.isArray(child)
       ) {
         stripped.push(childPath);
+        continue;
+      }
+      if (
+        key.toLowerCase() === "headers" &&
+        child &&
+        typeof child === "object" &&
+        !Array.isArray(child)
+      ) {
+        result[key] = sanitizeHeaders(child, childPath, stripped);
         continue;
       }
 

--- a/src/helpers/install_user_scripts.js
+++ b/src/helpers/install_user_scripts.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
-import { log } from "../common/utils.js";
+import { log, safeCopyFile } from "../common/utils.js";
 
 const HOME_DEFAULT = homedir();
 const PROJECT_ROOT_DEFAULT = path.resolve(__dirname, "..", "..");
@@ -54,7 +54,7 @@ export async function installUserScripts(opts = {}) {
   for (const entry of entries) {
     const src = path.join(scriptsSrc, entry.name);
     const dest = path.join(localBin, entry.name);
-    fs.copyFileSync(src, dest);
+    safeCopyFile(src, dest);
     fs.chmodSync(dest, 0o755);
     log.info(`  ${entry.name}`);
   }

--- a/src/helpers/skill_manager.js
+++ b/src/helpers/skill_manager.js
@@ -187,14 +187,55 @@ function cloneRepo(url, repoPath) {
 }
 
 /**
+ * Resolve the default branch name of origin for a cloned repo.
+ * Strategy:
+ *   1. git rev-parse --abbrev-ref origin/HEAD  (fast, works if already fetched)
+ *   2. git remote set-head origin --auto        (network call, sets it)
+ *   3. retry rev-parse
+ *   4. fallback "main"
+ * Strips the leading "origin/" prefix from the ref name.
+ * Never throws — callers rely on a usable fallback.
+ */
+export function resolveDefaultBranch(repoPath) {
+	const parseHead = () => {
+		const result = Bun.spawnSync(
+			["git", "rev-parse", "--abbrev-ref", "origin/HEAD"],
+			{ cwd: repoPath },
+		);
+		if (result.exitCode !== 0) return null;
+		const raw = new TextDecoder().decode(result.stdout).trim();
+		if (!raw || raw === "origin/HEAD") return null;
+		return raw.replace(/^origin\//, "");
+	};
+
+	try {
+		const branch = parseHead();
+		if (branch) return branch;
+
+		// origin/HEAD not set yet — auto-detect it
+		Bun.spawnSync(["git", "remote", "set-head", "origin", "--auto"], {
+			cwd: repoPath,
+		});
+
+		const retried = parseHead();
+		return retried ?? "main";
+	} catch {
+		return "main";
+	}
+}
+
+/**
  * Update existing repo in cache.
  * fetch+reset handles shallow clones and force-push scenarios (pull fails for
  * shallow repos). If update fails, keeps stale cache to preserve offline operation.
+ * Dynamically resolves the default branch instead of hardcoding "main".
  */
 function updateRepo(repoPath, url, repoName) {
 	log.info(`Updating ${repoName}...`);
 
-	const fetchResult = Bun.spawnSync(["git", "fetch", "origin", "main"], {
+	const branch = resolveDefaultBranch(repoPath);
+
+	const fetchResult = Bun.spawnSync(["git", "fetch", "origin", branch], {
 		cwd: repoPath,
 	});
 
@@ -204,8 +245,8 @@ function updateRepo(repoPath, url, repoName) {
 	}
 
 	const resetResult = Bun.spawnSync(
-		["git", "reset", "--hard", "origin/main"],
-		{ cwd: repoPath }
+		["git", "reset", "--hard", `origin/${branch}`],
+		{ cwd: repoPath },
 	);
 
 	if (resetResult.exitCode !== 0) {
@@ -306,14 +347,14 @@ export function listSkills(cacheDir) {
  * Ensure skills directory exists.
  * Exits on fatal errors (skills dir is prerequisite for symlink operations).
  */
-function ensureSkillsDir() {
-	if (!fs.existsSync(CLAUDE_SKILLS_DIR)) {
+function ensureSkillsDir(skillsDir = CLAUDE_SKILLS_DIR) {
+	if (!fs.existsSync(skillsDir)) {
 		try {
-			fs.mkdirSync(CLAUDE_SKILLS_DIR, { recursive: true });
+			fs.mkdirSync(skillsDir, { recursive: true });
 		} catch (error) {
 			if (error.code === "EACCES" || error.code === "ENOTDIR") {
 				log.error(
-					`Cannot create ${CLAUDE_SKILLS_DIR}: ${error.message}. Check permissions.`
+					`Cannot create ${skillsDir}: ${error.message}. Check permissions.`,
 				);
 				process.exit(1);
 			}
@@ -376,12 +417,12 @@ function createSymlinkForSkill(skill, source, destPath) {
  * Enforces priority: first occurrence of skill name wins (seenSkills Set).
  * Sources are processed in priority order (user first, then community).
  */
-function processSkill(skill, source, seenSkills) {
+function processSkill(skill, source, seenSkills, skillsDir = CLAUDE_SKILLS_DIR) {
 	if (seenSkills.has(skill.name)) {
 		return false;
 	}
 
-	const destPath = path.join(CLAUDE_SKILLS_DIR, skill.name);
+	const destPath = path.join(skillsDir, skill.name);
 
 	if (pathExists(destPath) && updateSymlinkIfNeeded(destPath, skill.path)) {
 		seenSkills.add(skill.name);
@@ -398,6 +439,11 @@ function processSkill(skill, source, seenSkills) {
 
 /**
  * Symlink a shared resource (directory or file) if not already linked.
+ * Safe-backup policy:
+ *   - If destPath is a symlink → unlink and relink (idempotent, no backup needed).
+ *   - If destPath is a real file or directory → rename to destPath.bak (removing
+ *     any stale destPath.bak first) then symlink. Logs a warning so the user knows
+ *     their data was moved rather than deleted.
  * Returns true if symlink was created, false if source doesn't exist.
  */
 function symlinkSharedResource(srcPath, destPath, isDir, sourceName) {
@@ -406,7 +452,29 @@ function symlinkSharedResource(srcPath, destPath, isDir, sourceName) {
 	}
 
 	if (pathExists(destPath)) {
-		fs.rmSync(destPath, { recursive: isDir, force: true });
+		let stat;
+		try {
+			stat = fs.lstatSync(destPath);
+		} catch {
+			stat = null;
+		}
+
+		if (stat?.isSymbolicLink()) {
+			// Already a symlink — just unlink and re-create below.
+			fs.unlinkSync(destPath);
+		} else {
+			// Real file or directory — back it up rather than destroying it.
+			const bakPath = `${destPath}.bak`;
+			// Remove any stale .bak first so renameSync doesn't fail on
+			// non-empty directory or existing file.
+			if (pathExists(bakPath)) {
+				fs.rmSync(bakPath, { recursive: true, force: true });
+			}
+			fs.renameSync(destPath, bakPath);
+			log.warning(
+				`moved existing ${path.basename(destPath)} to ${path.basename(bakPath)} — replaced by symlink from ${sourceName}`,
+			);
+		}
 	}
 
 	fs.symlinkSync(srcPath, destPath);
@@ -421,9 +489,13 @@ function symlinkSharedResource(srcPath, destPath, isDir, sourceName) {
  *
  * Symlinks-only invariant: Never copy skills. Symlinks maintain single source of
  * truth - cache updates immediately visible to Claude Code without re-sync.
+ *
+ * opts.skillsDir — override the destination directory (default: CLAUDE_SKILLS_DIR).
+ * Injected by tests to avoid touching the real ~/.claude/skills/.
  */
-export function mergeSkills(sources) {
-	ensureSkillsDir();
+export function mergeSkills(sources, opts = {}) {
+	const skillsDir = opts.skillsDir ?? CLAUDE_SKILLS_DIR;
+	ensureSkillsDir(skillsDir);
 	const seenSkills = new Set();
 	const linked = { scripts: false, claudeMd: false, readmeMd: false };
 
@@ -432,29 +504,29 @@ export function mergeSkills(sources) {
 
 		if (!linked.scripts) {
 			const src = path.join(skillsRoot, "scripts");
-			const dest = path.join(CLAUDE_SKILLS_DIR, "scripts");
+			const dest = path.join(skillsDir, "scripts");
 			linked.scripts = symlinkSharedResource(src, dest, true, source.name);
 		}
 
 		if (!linked.claudeMd) {
 			const src = path.join(skillsRoot, "CLAUDE.md");
-			const dest = path.join(CLAUDE_SKILLS_DIR, "CLAUDE.md");
+			const dest = path.join(skillsDir, "CLAUDE.md");
 			linked.claudeMd = symlinkSharedResource(src, dest, false, source.name);
 		}
 
 		if (!linked.readmeMd) {
 			const src = path.join(skillsRoot, "README.md");
-			const dest = path.join(CLAUDE_SKILLS_DIR, "README.md");
+			const dest = path.join(skillsDir, "README.md");
 			linked.readmeMd = symlinkSharedResource(src, dest, false, source.name);
 		}
 
 		const skills = listSkills(source.cachePath);
 		for (const skill of skills) {
-			processSkill(skill, source, seenSkills);
+			processSkill(skill, source, seenSkills, skillsDir);
 		}
 	}
 
-	log.success(`Merged ${seenSkills.size} skills to ${CLAUDE_SKILLS_DIR}`);
+	log.success(`Merged ${seenSkills.size} skills to ${skillsDir}`);
 }
 
 /**

--- a/src/os_scripts/cachyos.js
+++ b/src/os_scripts/cachyos.js
@@ -166,8 +166,15 @@ async function installBaseDependencies() {
   // // Then update the keyring packages
   // await runCommand("sudo pacman -Sy --noconfirm archlinux-keyring cachyos-keyring");
 
-  log.info("Updating system and installing base-devel...");
-  //   await runCommand("sudo pacman -Syu base-devel --noconfirm");
+  log.info("Installing base-devel and git (required for makepkg / paru build)...");
+  const baseDevelOk = await runCommand(
+    "sudo pacman -S --needed --noconfirm base-devel git",
+  );
+  if (!baseDevelOk) {
+    log.warning(
+      "base-devel/git install failed — paru build and AUR installs may fail.",
+    );
+  }
 
   log.info("Installing Rust via rustup...");
   await withSpinner("Installing Rust", () =>
@@ -190,11 +197,18 @@ async function installAurHelper() {
     return;
   }
   log.info("Installing paru...");
-  await withSpinner("Installing paru", () =>
+  // Remove any leftover build dir from a prior failed run so git clone succeeds.
+  fs.rmSync(PARU_BUILD_DIR, { recursive: true, force: true });
+  const paruOk = await withSpinner("Installing paru", () =>
     runCommand(
       `git clone ${PARU_AUR_URL} ${PARU_BUILD_DIR} && cd ${PARU_BUILD_DIR} && makepkg -si --noconfirm`,
     ),
   );
+  if (!paruOk) {
+    log.warning(
+      "paru installation failed — AUR package installs will be unavailable.",
+    );
+  }
 }
 
 async function installDevTools() {
@@ -363,7 +377,7 @@ async function configureFastfetch() {
   log.info("Configuring Fastfetch...");
   fs.mkdirSync(FASTFETCH_CONFIG_DIR, { recursive: true });
   if (fs.existsSync(CUSTOM_FASTFETCH_CONFIG_PATH)) {
-    fs.copyFileSync(
+    safeCopyFile(
       CUSTOM_FASTFETCH_CONFIG_PATH,
       path.join(FASTFETCH_CONFIG_DIR, "config.jsonc"),
     );
@@ -384,11 +398,7 @@ async function configureKde() {
         ".config",
         "kglobalshortcutsrc",
       );
-      if (fs.existsSync(kglobalshortcutsrc)) {
-        fs.copyFileSync(kglobalshortcutsrc, `${kglobalshortcutsrc}.bak`);
-        log.info(`Backed up existing shortcuts to ${kglobalshortcutsrc}.bak`);
-      }
-      fs.copyFileSync(KDE_SHORTCUTS_PATH, kglobalshortcutsrc);
+      safeCopyFile(KDE_SHORTCUTS_PATH, kglobalshortcutsrc);
       log.info("KDE shortcuts applied. Please log out and log back in.");
     } else {
       log.warning(`KDE shortcuts file not found at ${KDE_SHORTCUTS_PATH}`);
@@ -514,10 +524,10 @@ export async function installKdeGlass() {
   log.info("Cloning and building KDE Glass blur effect...");
   const buildDir = "/tmp/kwin-effects-glass";
 
-  // Remove old build directory if it exists
-  await runCommand(`rm -rf ${buildDir}`);
+  // Remove old build directory if it exists so git clone always starts clean.
+  fs.rmSync(buildDir, { recursive: true, force: true });
 
-  await runCommand(
+  const kdeGlassOk = await runCommand(
     `cd /tmp && ` +
       `git clone https://github.com/4v3ngR/kwin-effects-glass && ` +
       `cd kwin-effects-glass && ` +
@@ -527,10 +537,16 @@ export async function installKdeGlass() {
       `sudo make install`,
   );
 
-  log.success(
-    "KDE Glass blur effect installed successfully!\n" +
-      "Open System Settings > Desktop Effects, disable other blur effects, and enable Glass.",
-  );
+  if (kdeGlassOk) {
+    log.success(
+      "KDE Glass blur effect installed successfully!\n" +
+        "Open System Settings > Desktop Effects, disable other blur effects, and enable Glass.",
+    );
+  } else {
+    log.error(
+      "KDE Glass build failed — see output above; install manually from https://github.com/4v3ngR/kwin-effects-glass",
+    );
+  }
 }
 
 async function installSystemPackages() {

--- a/src/os_scripts/debian_server.js
+++ b/src/os_scripts/debian_server.js
@@ -1,9 +1,15 @@
 import fs from "node:fs";
-import { homedir } from "node:os";
+import { homedir, userInfo } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { withSpinner } from "../common/ui.js";
-import { commandExists, log, promptUser, runCommand } from "../common/utils.js";
+import {
+	commandExists,
+	log,
+	promptUser,
+	runCommand,
+	safeCopyFile,
+} from "../common/utils.js";
 import { configureClaude } from "../helpers/configure_claude.js";
 
 // --- Constants ---
@@ -19,6 +25,44 @@ const CONFIGS_DIR = path.join(PROJECT_ROOT, "configs");
 const CUSTOM_FISH_CONFIG_PATH = path.join(CONFIGS_DIR, "fish", "config.fish");
 
 // --- Helper Functions ---
+
+/**
+ * Return true when the host is Ubuntu (or an Ubuntu derivative). Reads
+ * /etc/os-release and checks `ID=ubuntu` or `ID_LIKE` containing `ubuntu`.
+ *
+ * The fish-shell PPA (`ppa:fish-shell/release-3`) is an Ubuntu Launchpad PPA;
+ * on actual Debian it 404s and `apt update` then fails, which can leave apt in
+ * a broken state. So we only add it on Ubuntu-family hosts.
+ *
+ * `osReleasePath` is injectable for tests.
+ */
+function isUbuntuFamily(osReleasePath = "/etc/os-release") {
+	let content;
+	try {
+		content = fs.readFileSync(osReleasePath, "utf-8");
+	} catch {
+		return false;
+	}
+
+	const fields = {};
+	for (const line of content.split("\n")) {
+		const eq = line.indexOf("=");
+		if (eq === -1) continue;
+		const key = line.slice(0, eq).trim();
+		// Strip surrounding quotes from the value (os-release allows them).
+		const value = line
+			.slice(eq + 1)
+			.trim()
+			.replace(/^["']|["']$/g, "");
+		fields[key] = value;
+	}
+
+	if (fields.ID === "ubuntu") return true;
+	if (fields.ID_LIKE) {
+		return fields.ID_LIKE.split(/\s+/).includes("ubuntu");
+	}
+	return false;
+}
 
 async function installEssentials() {
 	log.info("Updating system and installing essentials...");
@@ -64,13 +108,15 @@ async function setupSsh() {
 async function configureFishShell() {
 	if (!(await commandExists("fish"))) {
 		log.info("Installing Fish shell...");
-		// Only try adding PPA if add-apt-repository is available
-		if (await commandExists("add-apt-repository")) {
+		// The fish-shell PPA is an Ubuntu Launchpad PPA — only add it on the
+		// Ubuntu family. On real Debian it 404s and can break apt, so we fall
+		// back to the default repos there (might be an older fish).
+		if ((await commandExists("add-apt-repository")) && isUbuntuFamily()) {
 			await runCommand("sudo apt-add-repository -y ppa:fish-shell/release-3");
 			await runCommand("sudo apt update");
 		} else {
-			log.warning(
-				"add-apt-repository not found. Installing fish from default repositories (might be older version).",
+			log.info(
+				"Not an Ubuntu host (or add-apt-repository missing). Installing fish from default repositories (might be older version).",
 			);
 		}
 		await withSpinner("Installing fish", () =>
@@ -79,14 +125,21 @@ async function configureFishShell() {
 	}
 
 	if (await promptUser("Set Fish as the default shell?", true)) {
-		const fishPathProc = Bun.spawn(["which", "fish"]);
-		const fishPath = (await new Response(fishPathProc.stdout).text()).trim();
+		const fishPath = Bun.which("fish") ?? "";
 
-		if (fishPath) {
-			log.info("Setting Fish as the default shell...");
-			await runCommand(`sudo chsh -s ${fishPath} ${process.env.USER}`);
-		} else {
+		// Resolve the real login user from os.userInfo() rather than $USER:
+		// an unset $USER yields the literal string "undefined" as the chsh
+		// target (and risks falling through to root). Skip when falsy.
+		const username = userInfo().username;
+		if (!fishPath) {
 			log.warning("Could not find fish executable.");
+		} else if (!username) {
+			log.warning(
+				"Could not determine the current user — skipping default-shell change.",
+			);
+		} else {
+			log.info("Setting Fish as the default shell...");
+			await runCommand(`sudo chsh -s ${fishPath} ${username}`);
 		}
 	}
 
@@ -122,7 +175,9 @@ async function configureFishShell() {
 	);
 
 	if (fs.existsSync(CUSTOM_FISH_CONFIG_PATH)) {
-		fs.copyFileSync(
+		// safeCopyFile backs up any existing live config.fish to .bak before
+		// overwriting (and no-ops when already in sync).
+		safeCopyFile(
 			CUSTOM_FISH_CONFIG_PATH,
 			path.join(FISH_CONFIG_DIR, "config.fish"),
 		);
@@ -148,16 +203,31 @@ async function installDocker() {
 	}
 }
 
-async function setupFirewall() {
+export async function setupFirewall({
+	run = runCommand,
+	prompt = promptUser,
+} = {}) {
 	log.info("Setting up UFW...");
-	await runCommand("sudo ufw default deny incoming");
-	await runCommand("sudo ufw default allow outgoing");
-	await runCommand("sudo ufw allow ssh");
-	await runCommand("sudo ufw allow http");
-	await runCommand("sudo ufw allow https");
+	await run("sudo ufw default deny incoming");
+	await run("sudo ufw default allow outgoing");
 
-	if (await promptUser("Enable UFW now?", true)) {
-		await runCommand("sudo ufw enable");
+	// LOCKOUT GATE: on a remote/headless server, enabling UFW with a
+	// default-deny policy but no working SSH allow rule locks us out for good.
+	// Capture the allow-ssh result and refuse to enable (or even prompt) if it
+	// failed — better to leave UFW disabled than to brick remote access.
+	const sshAllowed = await run("sudo ufw allow ssh");
+	if (!sshAllowed) {
+		log.error(
+			"SSH allow rule failed — NOT enabling UFW (remote lockout risk). Fix and re-run.",
+		);
+		return;
+	}
+
+	await run("sudo ufw allow http");
+	await run("sudo ufw allow https");
+
+	if (await prompt("Enable UFW now?", true)) {
+		await run("sudo ufw enable");
 	}
 }
 
@@ -176,27 +246,64 @@ async function installNodejs() {
 	});
 }
 
-async function configureFail2ban() {
-	log.info("Configuring Fail2ban for SSH protection...");
-
-	const jailLocal = `[sshd]
+/**
+ * Build the fail2ban `jail.local` content for the [sshd] jail.
+ *
+ * `backend = systemd` is required on Debian 12+ / minimal images: there's no
+ * rsyslog by default, so `/var/log/auth.log` never gets written and the
+ * file-tailing backend makes fail2ban fail to start. The systemd backend reads
+ * the journal directly and ignores `logpath` (kept for readability and for
+ * hosts that do populate auth.log).
+ *
+ * Pure function (no I/O) so it's testable.
+ *
+ * @returns {string}
+ */
+export function buildFail2banJail() {
+	return `[sshd]
 enabled = true
 port = ssh
 filter = sshd
+backend = systemd
 logpath = /var/log/auth.log
 maxretry = 5
 bantime = 3600
 findtime = 600
 `;
+}
 
-	fs.writeFileSync("/tmp/jail.local", jailLocal);
-	await runCommand("sudo mv /tmp/jail.local /etc/fail2ban/jail.local");
+async function configureFail2ban() {
+	log.info("Configuring Fail2ban for SSH protection...");
+
+	fs.writeFileSync("/tmp/jail.local", buildFail2banJail());
+
+	const moved = await runCommand(
+		"sudo mv /tmp/jail.local /etc/fail2ban/jail.local",
+	);
+	if (!moved) {
+		log.warning(
+			"Could not install /etc/fail2ban/jail.local — skipping fail2ban enable/restart.",
+		);
+		return;
+	}
+
 	await runCommand("sudo systemctl enable fail2ban");
 	await runCommand("sudo systemctl restart fail2ban");
 	log.success("Fail2ban configured for SSH protection.");
 }
 
 export async function runDebianServerSetup() {
+	// SUDO PREFLIGHT: nearly every step shells out via `sudo`. Without a valid
+	// sudo session each one fails individually yet the run still reports
+	// "setup finished". Validate (and cache) credentials up front and bail
+	// early with a clear error instead.
+	if (!(await runCommand("sudo -v"))) {
+		log.error(
+			"Could not obtain sudo privileges — aborting Debian server setup.",
+		);
+		return;
+	}
+
 	await installEssentials();
 	await setupSsh();
 	await configureFishShell();

--- a/tests/cachyos.test.js
+++ b/tests/cachyos.test.js
@@ -240,3 +240,108 @@ describe("custom fish assets shipped by haoshoku", () => {
     expect(content).not.toMatch(/api[_-]?key\s*=\s*['"][^'"]+['"]/i);
   });
 });
+
+describe("installAurHelper robustness", () => {
+  it("calls fs.rmSync on PARU_BUILD_DIR before the runCommand that git-clones paru", () => {
+    // Ensures a leftover /tmp/paru from a prior failed run doesn't block cloning.
+    // The rmSync call must appear before the git clone runCommand inside installAurHelper.
+    const fnStart = CACHYOS_SRC.indexOf("async function installAurHelper");
+    const fnEnd = CACHYOS_SRC.indexOf("\nasync function ", fnStart + 1);
+    const fnBody = CACHYOS_SRC.slice(fnStart, fnEnd === -1 ? undefined : fnEnd);
+    const rmSyncIdx = fnBody.indexOf("fs.rmSync(PARU_BUILD_DIR");
+    const cloneRunCmdIdx = fnBody.indexOf("PARU_AUR_URL");
+    expect(rmSyncIdx).toBeGreaterThan(-1);
+    expect(cloneRunCmdIdx).toBeGreaterThan(-1);
+    expect(rmSyncIdx).toBeLessThan(cloneRunCmdIdx);
+  });
+
+  it("passes { recursive: true, force: true } to rmSync for PARU_BUILD_DIR", () => {
+    expect(CACHYOS_SRC).toMatch(
+      /fs\.rmSync\(PARU_BUILD_DIR,\s*\{\s*recursive:\s*true,\s*force:\s*true\s*\}\)/,
+    );
+  });
+
+  it("captures the runCommand result in installAurHelper and warns on failure", () => {
+    // The paru build command result must be captured (assigned to a variable or
+    // otherwise tested), and a log.warning must follow it in installAurHelper.
+    // We verify by checking that both an assignment to the paru spinner call and
+    // a log.warning appear inside the installAurHelper function body.
+    const fnStart = CACHYOS_SRC.indexOf("async function installAurHelper");
+    const fnEnd = CACHYOS_SRC.indexOf("\nasync function ", fnStart + 1);
+    const fnBody = CACHYOS_SRC.slice(fnStart, fnEnd === -1 ? undefined : fnEnd);
+    expect(fnBody).toMatch(/const\s+\w+\s*=\s*await\s+withSpinner/);
+    expect(fnBody).toMatch(/log\.warning/);
+  });
+});
+
+describe("installBaseDependencies base-devel requirement", () => {
+  it("installs base-devel and git via pacman (required for makepkg / paru build)", () => {
+    // Must be an uncommented (active) call — check the string is present in the source.
+    // Allow for an optional trailing comma before the closing paren (biome style).
+    expect(CACHYOS_SRC).toMatch(
+      /runCommand\(\s*["']sudo pacman -S --needed --noconfirm base-devel git["'],?\s*\)/,
+    );
+  });
+
+  it("checks the result of the base-devel install and warns on failure", () => {
+    const fnStart = CACHYOS_SRC.indexOf("async function installBaseDependencies");
+    const fnEnd = CACHYOS_SRC.indexOf("\nasync function ", fnStart + 1);
+    const fnBody = CACHYOS_SRC.slice(fnStart, fnEnd === -1 ? undefined : fnEnd);
+    // Result captured into a variable (trailing comma allowed by biome style)
+    expect(fnBody).toMatch(
+      /const\s+\w+\s*=\s*await\s+runCommand\(\s*["']sudo pacman -S --needed --noconfirm base-devel git["']/,
+    );
+    expect(fnBody).toMatch(/log\.warning/);
+  });
+});
+
+describe("installKdeGlass result gating", () => {
+  it("captures the result of the kwin-effects-glass build runCommand", () => {
+    const fnStart = CACHYOS_SRC.indexOf("export async function installKdeGlass");
+    const fnEnd = CACHYOS_SRC.indexOf("\nasync function ", fnStart + 1);
+    // installKdeGlass is the last function — slice to end if no next function found
+    const fnBody = CACHYOS_SRC.slice(fnStart, fnEnd === -1 ? undefined : fnEnd);
+    // The big build chain must be assigned
+    expect(fnBody).toMatch(/const\s+\w+\s*=\s*await\s+runCommand\(/);
+  });
+
+  it("only prints success message when the build runCommand returned true", () => {
+    const fnStart = CACHYOS_SRC.indexOf("export async function installKdeGlass");
+    const fnBody = CACHYOS_SRC.slice(fnStart);
+    // success call gated on the result variable
+    expect(fnBody).toMatch(/if\s*\(\w+\)\s*\{[\s\S]*?log\.success/);
+  });
+
+  it("logs an error with manual-install URL when the build fails", () => {
+    // log.error call may have whitespace/newline between '(' and the string.
+    expect(CACHYOS_SRC).toMatch(
+      /log\.error\(\s*["'`]KDE Glass build failed/,
+    );
+    expect(CACHYOS_SRC).toMatch(
+      /https:\/\/github\.com\/4v3ngR\/kwin-effects-glass/,
+    );
+  });
+
+  it("uses fs.rmSync instead of runCommand('rm -rf …') for buildDir cleanup", () => {
+    const fnStart = CACHYOS_SRC.indexOf("export async function installKdeGlass");
+    const fnBody = CACHYOS_SRC.slice(fnStart);
+    // Must NOT use a shell rm -rf for buildDir
+    expect(fnBody).not.toMatch(/runCommand\(`rm -rf \$\{buildDir\}`\)/);
+    // Must use fs.rmSync
+    expect(fnBody).toMatch(
+      /fs\.rmSync\(buildDir,\s*\{\s*recursive:\s*true,\s*force:\s*true\s*\}\)/,
+    );
+  });
+});
+
+describe("configureFastfetch safeCopyFile", () => {
+  it("uses safeCopyFile instead of fs.copyFileSync for the fastfetch config", () => {
+    const fnStart = CACHYOS_SRC.indexOf("async function configureFastfetch");
+    const fnEnd = CACHYOS_SRC.indexOf("\nasync function ", fnStart + 1);
+    const fnBody = CACHYOS_SRC.slice(fnStart, fnEnd === -1 ? undefined : fnEnd);
+    // Must NOT use bare fs.copyFileSync for the fastfetch config copy
+    expect(fnBody).not.toMatch(/fs\.copyFileSync\(/);
+    // Must use safeCopyFile
+    expect(fnBody).toMatch(/safeCopyFile\(/);
+  });
+});

--- a/tests/cli_utils.test.js
+++ b/tests/cli_utils.test.js
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { detectOS, findActiveModeFlags } from "../src/common/cli_utils.js";
+
+describe("detectOS", () => {
+	let tmpDir;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-os-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	const writeOsRelease = (content) => {
+		const p = path.join(tmpDir, "os-release");
+		fs.writeFileSync(p, content);
+		return p;
+	};
+
+	it("detects CachyOS (ID=cachyos) as cachyos", () => {
+		const p = writeOsRelease('NAME="CachyOS"\nID=cachyos\nID_LIKE=arch\n');
+		expect(detectOS(p)).toBe("cachyos");
+	});
+
+	it("detects vanilla Arch (ID=arch only, no ID_LIKE) as cachyos-family", () => {
+		const p = writeOsRelease('NAME="Arch Linux"\nID=arch\n');
+		expect(detectOS(p)).toBe("cachyos");
+	});
+
+	it("detects an Arch derivative (ID_LIKE=arch) as cachyos-family", () => {
+		const p = writeOsRelease('NAME="EndeavourOS"\nID=endeavouros\nID_LIKE=arch\n');
+		expect(detectOS(p)).toBe("cachyos");
+	});
+
+	it("detects Debian (ID=debian) as debian-server", () => {
+		const p = writeOsRelease('NAME="Debian GNU/Linux"\nID=debian\n');
+		expect(detectOS(p)).toBe("debian-server");
+	});
+
+	it("detects Ubuntu (ID=ubuntu ID_LIKE=debian) as debian-server", () => {
+		const p = writeOsRelease('NAME="Ubuntu"\nID=ubuntu\nID_LIKE=debian\n');
+		expect(detectOS(p)).toBe("debian-server");
+	});
+
+	it("returns null when the os-release file is missing", () => {
+		const p = path.join(tmpDir, "does-not-exist");
+		expect(detectOS(p)).toBeNull();
+	});
+
+	it("returns null for garbage / unrecognized content", () => {
+		const p = writeOsRelease("this is not a valid os-release file\n!!!\n");
+		expect(detectOS(p)).toBeNull();
+	});
+
+	it("defaults to /etc/os-release when called with no argument", () => {
+		// Smoke check: a no-arg call must not throw and returns a known shape.
+		const result = detectOS();
+		expect(result === null || typeof result === "string").toBe(true);
+	});
+});
+
+describe("findActiveModeFlags", () => {
+	it("returns an empty array when no mode flags are set", () => {
+		expect(findActiveModeFlags({})).toEqual([]);
+	});
+
+	it("ignores the --os option (not a mode flag)", () => {
+		expect(findActiveModeFlags({ os: "cachyos" })).toEqual([]);
+	});
+
+	it("returns the single set flag when exactly one is set", () => {
+		expect(findActiveModeFlags({ claude: true })).toEqual(["claude"]);
+	});
+
+	it("ignores falsy flag values", () => {
+		expect(findActiveModeFlags({ claude: false, skills: undefined })).toEqual(
+			[],
+		);
+	});
+
+	it("returns both names when two mode flags are set", () => {
+		const result = findActiveModeFlags({ claude: true, zed: true });
+		expect(result.length).toBe(2);
+		expect(result).toContain("claude");
+		expect(result).toContain("zed");
+	});
+
+	it("recognizes every mutually-exclusive mode flag", () => {
+		const allFlags = [
+			"claude",
+			"claudeBackup",
+			"claudeUpdate",
+			"skills",
+			"skillsUpdate",
+			"skillsList",
+			"superpowers",
+			"zed",
+			"zedBackup",
+			"zedTheme",
+			"caelestiaPrefs",
+			"caelestiaPrefsBackup",
+			"sddmPosthook",
+			"audio",
+			"audioBackup",
+			"mimeapps",
+			"mimeappsBackup",
+			"lockfix",
+			"lockfixBackup",
+			"kdeTheme",
+			"kdeThemeBackup",
+			"kdeGlass",
+			"hyprland",
+		];
+		for (const flag of allFlags) {
+			expect(findActiveModeFlags({ [flag]: true })).toEqual([flag]);
+		}
+	});
+});

--- a/tests/configure_caelestia_prefs.test.js
+++ b/tests/configure_caelestia_prefs.test.js
@@ -222,6 +222,51 @@ describe("syncCaelestiaPrefs — deploys device-specific hypr-user variant", () 
 			),
 		).toMatch(/pc variant/);
 	});
+
+	it("backs up a user-owned live hypr-user.conf to .bak before overwriting", async () => {
+		seedPcAndLaptop();
+		writeDeviceType("pc");
+		// User had their own monitor config living at the deploy target.
+		const liveDir = path.join(tmpHome, ".config", "caelestia");
+		fs.mkdirSync(liveDir, { recursive: true });
+		const userMonitorConf =
+			"# user's own monitor config\nmonitor = HDMI-A-2, 1920x1080, 0x0, 1\n";
+		fs.writeFileSync(path.join(liveDir, "hypr-user.conf"), userMonitorConf);
+
+		await prefs.syncCaelestiaPrefs({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		// User's original lands in .bak, not vanished; repo variant is now live.
+		expect(
+			fs.readFileSync(path.join(liveDir, "hypr-user.conf.bak"), "utf8"),
+		).toBe(userMonitorConf);
+		expect(
+			fs.readFileSync(path.join(liveDir, "hypr-user.conf"), "utf8"),
+		).toMatch(/pc variant/);
+	});
+
+	it("backs up a user-owned live cli.json to .bak before overwriting", async () => {
+		seedPcAndLaptop();
+		writeDeviceType("pc");
+		const liveDir = path.join(tmpHome, ".config", "caelestia");
+		fs.mkdirSync(liveDir, { recursive: true });
+		const userCli = JSON.stringify({ toggles: { userOwned: {} } }, null, 2);
+		fs.writeFileSync(path.join(liveDir, "cli.json"), userCli);
+
+		await prefs.syncCaelestiaPrefs({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		expect(fs.readFileSync(path.join(liveDir, "cli.json.bak"), "utf8")).toBe(
+			userCli,
+		);
+		expect(
+			JSON.parse(fs.readFileSync(path.join(liveDir, "cli.json"), "utf8")),
+		).toEqual({ toggles: { fixture: {} } });
+	});
 });
 
 describe("backupCaelestiaPrefs — ~/.config/caelestia/ → configs/caelestia/<variant>", () => {
@@ -358,6 +403,99 @@ describe("backupCaelestiaPrefs — ~/.config/caelestia/ → configs/caelestia/<v
 				projectRoot: tmpProjectRoot,
 			}),
 		).resolves.toBeUndefined();
+	});
+
+	it("does NOT clobber a non-empty repo variant with an empty live placeholder", async () => {
+		writeDeviceType("pc");
+		// Repo already holds a curated PC variant (the source of truth).
+		const repoDir = path.join(tmpProjectRoot, "configs", "caelestia");
+		const curated = "# curated pc variant\nmonitor = DP-1, 2560x1440, 0x0, 1\n";
+		fs.writeFileSync(path.join(repoDir, "hypr-user-pc.conf"), curated);
+
+		// Live file is the empty placeholder installCaelestia pre-creates.
+		const liveDir = path.join(tmpHome, ".config", "caelestia");
+		fs.mkdirSync(liveDir, { recursive: true });
+		fs.writeFileSync(path.join(liveDir, "hypr-user.conf"), "");
+
+		const messages = [];
+		const originalLog = console.log;
+		console.log = (...args) => messages.push(args.join(" "));
+		try {
+			await prefs.backupCaelestiaPrefs({
+				home: tmpHome,
+				projectRoot: tmpProjectRoot,
+			});
+		} finally {
+			console.log = originalLog;
+		}
+
+		// Curated repo variant must survive untouched.
+		expect(fs.readFileSync(path.join(repoDir, "hypr-user-pc.conf"), "utf8")).toBe(
+			curated,
+		);
+		expect(messages.join("\n")).toMatch(/hypr-user/i);
+	});
+
+	it("also skips when the live placeholder is whitespace-only", async () => {
+		writeDeviceType("laptop");
+		const repoDir = path.join(tmpProjectRoot, "configs", "caelestia");
+		const curated = "# curated laptop variant\nmonitor = eDP-1\n";
+		fs.writeFileSync(path.join(repoDir, "hypr-user-laptop.conf"), curated);
+
+		const liveDir = path.join(tmpHome, ".config", "caelestia");
+		fs.mkdirSync(liveDir, { recursive: true });
+		fs.writeFileSync(path.join(liveDir, "hypr-user.conf"), "  \n\t\n");
+
+		await prefs.backupCaelestiaPrefs({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		expect(
+			fs.readFileSync(path.join(repoDir, "hypr-user-laptop.conf"), "utf8"),
+		).toBe(curated);
+	});
+
+	it("still backs up an empty live file when the repo target is also empty/absent", async () => {
+		writeDeviceType("pc");
+		// No curated repo variant exists yet — an empty live file is fine to land.
+		const liveDir = path.join(tmpHome, ".config", "caelestia");
+		fs.mkdirSync(liveDir, { recursive: true });
+		fs.writeFileSync(path.join(liveDir, "hypr-user.conf"), "");
+
+		await prefs.backupCaelestiaPrefs({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const repoVariant = path.join(
+			tmpProjectRoot,
+			"configs",
+			"caelestia",
+			"hypr-user-pc.conf",
+		);
+		expect(fs.existsSync(repoVariant)).toBe(true);
+		expect(fs.readFileSync(repoVariant, "utf8")).toBe("");
+	});
+
+	it("backs up a non-empty live file normally even when repo target is non-empty", async () => {
+		writeDeviceType("pc");
+		const repoDir = path.join(tmpProjectRoot, "configs", "caelestia");
+		fs.writeFileSync(path.join(repoDir, "hypr-user-pc.conf"), "# old curated\n");
+
+		const liveDir = path.join(tmpHome, ".config", "caelestia");
+		fs.mkdirSync(liveDir, { recursive: true });
+		const newLive = "# user edited monitor config\nmonitor = DP-3\n";
+		fs.writeFileSync(path.join(liveDir, "hypr-user.conf"), newLive);
+
+		await prefs.backupCaelestiaPrefs({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		expect(
+			fs.readFileSync(path.join(repoDir, "hypr-user-pc.conf"), "utf8"),
+		).toBe(newLive);
 	});
 });
 

--- a/tests/configure_claude.test.js
+++ b/tests/configure_claude.test.js
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+	MANAGED_DIRS,
 	PERSONAL_FILES,
 	syncClaudeConfig,
 } from "../src/helpers/configure_claude.js";
@@ -77,5 +78,108 @@ describe("syncClaudeConfig() warns on missing sources", () => {
 		expect(warnings.some((w) => w.includes("statusline-command.sh"))).toBe(
 			false,
 		);
+	});
+});
+
+describe("syncClaudeConfig() preserves the user's live settings.json via .bak", () => {
+	let tmpDir;
+	let configsDir;
+	let claudeHome;
+	let claudeDir;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-claudebak-"));
+		configsDir = path.join(tmpDir, "configs", "claude");
+		claudeHome = path.join(tmpDir, "claude-home");
+		claudeDir = path.join(claudeHome, ".claude");
+		fs.mkdirSync(configsDir, { recursive: true });
+		fs.mkdirSync(claudeDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("backs up a differing live settings.json to settings.json.bak before overwriting", async () => {
+		// User's live settings.json carries runtime-mutated state (e.g. enabled
+		// plugins) that differs from the bundled template.
+		const liveSettings = `${JSON.stringify({ enabledPlugins: { "x@y": true } }, null, 2)}\n`;
+		fs.writeFileSync(path.join(claudeDir, "settings.json"), liveSettings);
+
+		const bundledSettings = `${JSON.stringify({ permissions: { allow: [] } }, null, 2)}\n`;
+		fs.writeFileSync(path.join(configsDir, "settings.json"), bundledSettings);
+		fs.writeFileSync(path.join(configsDir, "CLAUDE.md"), "# test\n");
+		fs.writeFileSync(path.join(configsDir, "statusline-command.sh"), "#!/bin/sh\n");
+
+		await syncClaudeConfig({ srcDir: configsDir, claudeHome });
+
+		// Original live config preserved in .bak; bundled config now live.
+		expect(
+			fs.readFileSync(path.join(claudeDir, "settings.json.bak"), "utf-8"),
+		).toBe(liveSettings);
+		expect(fs.readFileSync(path.join(claudeDir, "settings.json"), "utf-8")).toBe(
+			bundledSettings,
+		);
+	});
+
+	it("does not clobber the original .bak when settings.json is synced a second time", async () => {
+		const originalLive = `${JSON.stringify({ original: true }, null, 2)}\n`;
+		fs.writeFileSync(path.join(claudeDir, "settings.json"), originalLive);
+
+		const bundledSettings = `${JSON.stringify({ bundled: true }, null, 2)}\n`;
+		fs.writeFileSync(path.join(configsDir, "settings.json"), bundledSettings);
+		fs.writeFileSync(path.join(configsDir, "CLAUDE.md"), "# test\n");
+		fs.writeFileSync(path.join(configsDir, "statusline-command.sh"), "#!/bin/sh\n");
+
+		// First sync: original → .bak, bundled → live.
+		await syncClaudeConfig({ srcDir: configsDir, claudeHome });
+		// Second sync: live already equals bundled → no-op, .bak must stay pristine.
+		await syncClaudeConfig({ srcDir: configsDir, claudeHome });
+
+		expect(
+			fs.readFileSync(path.join(claudeDir, "settings.json.bak"), "utf-8"),
+		).toBe(originalLive);
+	});
+});
+
+describe("syncClaudeConfig() replaces MANAGED_DIRS (stale entries do not linger)", () => {
+	let tmpDir;
+	let configsDir;
+	let claudeHome;
+	let claudeDir;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-claudedir-"));
+		configsDir = path.join(tmpDir, "configs", "claude");
+		claudeHome = path.join(tmpDir, "claude-home");
+		claudeDir = path.join(claudeHome, ".claude");
+		fs.mkdirSync(configsDir, { recursive: true });
+		fs.mkdirSync(claudeDir, { recursive: true });
+		// PERSONAL_FILES are required so the loop doesn't warn; content is irrelevant here.
+		for (const f of PERSONAL_FILES) {
+			fs.writeFileSync(path.join(configsDir, f.src), "x");
+		}
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("removes a stale file inside a MANAGED_DIR that the new bundle no longer ships", async () => {
+		const managed = MANAGED_DIRS[0];
+
+		// Bundle ships only keep.md.
+		fs.mkdirSync(path.join(configsDir, managed), { recursive: true });
+		fs.writeFileSync(path.join(configsDir, managed, "keep.md"), "keep\n");
+
+		// Live dir has a leftover from a previous bundle that was since deleted.
+		fs.mkdirSync(path.join(claudeDir, managed), { recursive: true });
+		fs.writeFileSync(path.join(claudeDir, managed, "stale.md"), "stale\n");
+
+		await syncClaudeConfig({ srcDir: configsDir, claudeHome });
+
+		const liveManaged = path.join(claudeDir, managed);
+		expect(fs.existsSync(path.join(liveManaged, "stale.md"))).toBe(false);
+		expect(fs.existsSync(path.join(liveManaged, "keep.md"))).toBe(true);
 	});
 });

--- a/tests/configure_git.test.js
+++ b/tests/configure_git.test.js
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { configureGit } from "../src/helpers/configure_git.js";
+
+// Each test gets a throwaway HOME so we never touch the real ~/.gitconfig.
+let tmpHome;
+
+beforeEach(() => {
+	tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-git-"));
+});
+
+afterEach(() => {
+	fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+// A prompts() stand-in: hand it the answer objects to return in order. Each
+// call shifts the next scripted response off the queue.
+function makePromptFn(responses) {
+	const queue = [...responses];
+	const calls = [];
+	const promptFn = async (questions) => {
+		calls.push(questions);
+		return queue.shift() ?? {};
+	};
+	return { promptFn, calls };
+}
+
+// A Bun.spawn-style runner stand-in returning a scripted exit code, recording
+// every argv it was handed.
+function makeRunner({ exitCode = 0 } = {}) {
+	const calls = [];
+	const runner = async (argv) => {
+		calls.push(argv);
+		return { exitCode };
+	};
+	return { runner, calls };
+}
+
+// Minimal profile answers for createProfile's prompts().
+const personalAnswers = {
+	email: "me@personal.example",
+	username: "Me Personal",
+	githubUser: "mepersonal",
+};
+const workAnswers = {
+	email: "me@work.example",
+	username: "Me Work",
+	githubUser: "mework",
+};
+
+// Convenience: run configureGit with no work profile (promptUser answers false).
+async function runNoWork(opts = {}) {
+	const { promptFn } = makePromptFn([personalAnswers]);
+	return configureGit({
+		home: tmpHome,
+		promptFn,
+		promptUser: async () => false,
+		runner: makeRunner().runner,
+		startAgent: async () => {},
+		...opts,
+	});
+}
+
+describe("configureGit — global ~/.gitconfig backup", () => {
+	it("backs up an existing differing ~/.gitconfig to .bak before overwriting", async () => {
+		const gitConfigPath = path.join(tmpHome, ".gitconfig");
+		fs.writeFileSync(gitConfigPath, "old user content\n");
+
+		await runNoWork();
+
+		const bak = `${gitConfigPath}.bak`;
+		expect(fs.existsSync(bak)).toBe(true);
+		expect(fs.readFileSync(bak, "utf8")).toBe("old user content\n");
+		// The live file was overwritten with the generated includeIf config.
+		expect(fs.readFileSync(gitConfigPath, "utf8")).toContain(
+			'[includeIf "gitdir:~/personal/"]',
+		);
+	});
+
+	it("does NOT create a .bak when no ~/.gitconfig exists", async () => {
+		const gitConfigPath = path.join(tmpHome, ".gitconfig");
+		expect(fs.existsSync(gitConfigPath)).toBe(false);
+
+		await runNoWork();
+
+		expect(fs.existsSync(`${gitConfigPath}.bak`)).toBe(false);
+		expect(fs.existsSync(gitConfigPath)).toBe(true);
+	});
+
+	it("skips the write entirely when ~/.gitconfig already matches (no .bak)", async () => {
+		const gitConfigPath = path.join(tmpHome, ".gitconfig");
+		// First run to compute the exact content the generator produces.
+		await runNoWork();
+		const generated = fs.readFileSync(gitConfigPath, "utf8");
+
+		// Reset: pre-seed the live file with that exact content, no stale .bak.
+		fs.writeFileSync(gitConfigPath, generated);
+		fs.rmSync(`${gitConfigPath}.bak`, { force: true });
+
+		await runNoWork();
+
+		expect(fs.existsSync(`${gitConfigPath}.bak`)).toBe(false);
+		expect(fs.readFileSync(gitConfigPath, "utf8")).toBe(generated);
+	});
+});
+
+describe("configureGit — includeIf global config content", () => {
+	it("emits only the personal includeIf when no work profile is created", async () => {
+		await runNoWork();
+		const content = fs.readFileSync(path.join(tmpHome, ".gitconfig"), "utf8");
+		expect(content).toContain('[includeIf "gitdir:~/personal/"]');
+		expect(content).toContain("path = ~/personal/.gitconfig.personal");
+		expect(content).not.toContain('[includeIf "gitdir:~/work/"]');
+	});
+
+	it("emits both personal and work includeIf when a work profile is created", async () => {
+		const { promptFn } = makePromptFn([workAnswers, personalAnswers]);
+		await configureGit({
+			home: tmpHome,
+			promptFn,
+			promptUser: async () => true,
+			runner: makeRunner().runner,
+			startAgent: async () => {},
+		});
+		const content = fs.readFileSync(path.join(tmpHome, ".gitconfig"), "utf8");
+		expect(content).toContain('[includeIf "gitdir:~/personal/"]');
+		expect(content).toContain('[includeIf "gitdir:~/work/"]');
+		expect(content).toContain("path = ~/work/.gitconfig.work");
+	});
+});
+
+describe("createProfile — SSH keygen guards", () => {
+	it("passes the email as a literal argv element to ssh-keygen (no shell interpolation)", async () => {
+		const { runner, calls } = makeRunner();
+		const trickyEmail = 'a"; rm -rf ~ #@evil.example';
+		const { promptFn } = makePromptFn([
+			{ ...personalAnswers, email: trickyEmail },
+		]);
+		await configureGit({
+			home: tmpHome,
+			promptFn,
+			promptUser: async () => false,
+			runner,
+			startAgent: async () => {},
+		});
+		// First runner call is ssh-keygen; the email must be a discrete argv entry.
+		const keygen = calls.find((argv) => argv[0] === "ssh-keygen");
+		expect(keygen).toBeDefined();
+		expect(keygen).toContain(trickyEmail);
+		// And it is a standalone element (the -C flag's value), never concatenated
+		// into a shell string.
+		const cIdx = keygen.indexOf("-C");
+		expect(cIdx).toBeGreaterThan(-1);
+		expect(keygen[cIdx + 1]).toBe(trickyEmail);
+	});
+
+	it("writes signing config when keygen succeeds", async () => {
+		const { runner } = makeRunner({ exitCode: 0 });
+		const { promptFn } = makePromptFn([personalAnswers]);
+		await configureGit({
+			home: tmpHome,
+			promptFn,
+			promptUser: async () => false,
+			runner,
+			startAgent: async () => {},
+		});
+		const profilePath = path.join(
+			tmpHome,
+			"personal",
+			".gitconfig.personal",
+		);
+		const content = fs.readFileSync(profilePath, "utf8");
+		expect(content).toContain("signingkey =");
+		expect(content).toContain("gpgsign = true");
+		expect(content).toContain("format = ssh");
+		expect(content).toContain("sshCommand =");
+	});
+
+	it("omits signing config when keygen FAILS (non-zero exit)", async () => {
+		const { runner } = makeRunner({ exitCode: 1 });
+		const { promptFn } = makePromptFn([personalAnswers]);
+		await configureGit({
+			home: tmpHome,
+			promptFn,
+			promptUser: async () => false,
+			runner,
+			startAgent: async () => {},
+		});
+		const profilePath = path.join(
+			tmpHome,
+			"personal",
+			".gitconfig.personal",
+		);
+		const content = fs.readFileSync(profilePath, "utf8");
+		// User identity still written...
+		expect(content).toContain("email = me@personal.example");
+		expect(content).toContain("name = Me Personal");
+		// ...but every signing-related directive is absent.
+		expect(content).not.toContain("signingkey");
+		expect(content).not.toContain("gpgsign");
+		expect(content).not.toContain("format = ssh");
+		expect(content).not.toContain("sshCommand");
+	});
+
+	it("SKIPS keygen when the key already exists but keeps signing config", async () => {
+		// Pre-create the personal key so generation must be skipped.
+		const sshDir = path.join(tmpHome, ".ssh");
+		fs.mkdirSync(sshDir, { recursive: true });
+		const keyPath = path.join(sshDir, "personal_key");
+		fs.writeFileSync(keyPath, "PRE-EXISTING KEY\n");
+
+		const { runner, calls } = makeRunner({ exitCode: 0 });
+		const { promptFn } = makePromptFn([personalAnswers]);
+		await configureGit({
+			home: tmpHome,
+			promptFn,
+			promptUser: async () => false,
+			runner,
+			startAgent: async () => {},
+		});
+
+		// ssh-keygen must NOT have been invoked.
+		expect(calls.find((argv) => argv[0] === "ssh-keygen")).toBeUndefined();
+		// The existing key is untouched.
+		expect(fs.readFileSync(keyPath, "utf8")).toBe("PRE-EXISTING KEY\n");
+		// Signing config is still written (we keep using the existing key).
+		const content = fs.readFileSync(
+			path.join(tmpHome, "personal", ".gitconfig.personal"),
+			"utf8",
+		);
+		expect(content).toContain("signingkey =");
+		expect(content).toContain("gpgsign = true");
+	});
+});

--- a/tests/configure_hyprland.test.js
+++ b/tests/configure_hyprland.test.js
@@ -422,6 +422,102 @@ describe("installCaelestia (slim 5.0.0 — Caelestia only, no Ocean overlay)", (
 		expect(shellConfig.services.weatherLocation).toBe("Bengaluru");
 		expect(shellConfig.services.useTwelveHourClock).toBe(false);
 	});
+
+	it("renames a malformed shell.json to .bak and still writes valid config", async () => {
+		const shellConfigPath = path.join(
+			tmpHome,
+			".config",
+			"caelestia",
+			"shell.json",
+		);
+		fs.mkdirSync(path.dirname(shellConfigPath), { recursive: true });
+		const malformed = "{ services: not valid json,,,";
+		fs.writeFileSync(shellConfigPath, malformed);
+
+		const { run } = makeRecorder();
+		const exists = async (cmd) => cmd === "fish" || cmd === "caelestia";
+
+		const messages = [];
+		const originalLog = console.log;
+		console.log = (...args) => messages.push(args.join(" "));
+		try {
+			await hyprland.installCaelestia({ home: tmpHome, run, exists });
+		} finally {
+			console.log = originalLog;
+		}
+
+		// Malformed original preserved verbatim in the .bak sibling.
+		expect(fs.readFileSync(`${shellConfigPath}.bak`, "utf8")).toBe(malformed);
+		// New shell.json is valid JSON with the 24-hour clock forced.
+		const shellConfig = JSON.parse(fs.readFileSync(shellConfigPath, "utf8"));
+		expect(shellConfig.services.useTwelveHourClock).toBe(false);
+		// A warning referenced both the malformed file and its backup.
+		expect(messages.join("\n")).toMatch(/shell\.json/i);
+		expect(messages.join("\n")).toMatch(/\.bak/);
+	});
+});
+
+describe("configureCaelestiaShell — malformed shell.json handling", () => {
+	let tmpHome;
+
+	beforeEach(() => {
+		tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-shelljson-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpHome, { recursive: true, force: true });
+	});
+
+	it("renames the malformed file to shell.json.bak and continues with {}", () => {
+		const shellConfigPath = path.join(
+			tmpHome,
+			".config",
+			"caelestia",
+			"shell.json",
+		);
+		fs.mkdirSync(path.dirname(shellConfigPath), { recursive: true });
+		const malformed = "}}} not json {{{";
+		fs.writeFileSync(shellConfigPath, malformed);
+
+		const messages = [];
+		const originalLog = console.log;
+		console.log = (...args) => messages.push(args.join(" "));
+		try {
+			expect(() =>
+				hyprland.configureCaelestiaShell({ home: tmpHome }),
+			).not.toThrow();
+		} finally {
+			console.log = originalLog;
+		}
+
+		expect(fs.readFileSync(`${shellConfigPath}.bak`, "utf8")).toBe(malformed);
+		const shellConfig = JSON.parse(fs.readFileSync(shellConfigPath, "utf8"));
+		// Starting from {} means only the forced default lands.
+		expect(shellConfig.services.useTwelveHourClock).toBe(false);
+		expect(messages.join("\n")).toMatch(/shell\.json/i);
+		expect(messages.join("\n")).toMatch(/\.bak/);
+	});
+
+	it("preserves a valid existing shell.json (no .bak rename)", () => {
+		const shellConfigPath = path.join(
+			tmpHome,
+			".config",
+			"caelestia",
+			"shell.json",
+		);
+		fs.mkdirSync(path.dirname(shellConfigPath), { recursive: true });
+		fs.writeFileSync(
+			shellConfigPath,
+			JSON.stringify({ services: { weatherLocation: "Pune" } }),
+		);
+
+		hyprland.configureCaelestiaShell({ home: tmpHome });
+
+		expect(fs.existsSync(`${shellConfigPath}.bak`)).toBe(false);
+		const shellConfig = JSON.parse(fs.readFileSync(shellConfigPath, "utf8"));
+		expect(shellConfig.services.weatherLocation).toBe("Pune");
+		expect(shellConfig.services.useTwelveHourClock).toBe(false);
+	});
 });
 
 describe("promptDesktopEnvironment", () => {

--- a/tests/configure_kde_theme.test.js
+++ b/tests/configure_kde_theme.test.js
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import * as kdeTheme from "../src/helpers/configure_kde_theme.js";
+
+let tmpHome;
+let tmpProjectRoot;
+
+function kdeBundle(tmpProjectRoot) {
+	return path.join(tmpProjectRoot, "configs", "kde");
+}
+
+function seedFileComponent(tmpProjectRoot) {
+	// Seed the color-schemes/Ocean.colors file component into the bundle.
+	const bundlePath = path.join(
+		kdeBundle(tmpProjectRoot),
+		"color-schemes",
+		"Ocean.colors",
+	);
+	fs.mkdirSync(path.dirname(bundlePath), { recursive: true });
+	fs.writeFileSync(bundlePath, "[Colors:Button]\nBackgroundNormal=44,62,80\n");
+	return bundlePath;
+}
+
+function seedDirComponent(tmpProjectRoot) {
+	// Seed the look-and-feel/Ocean directory component into the bundle.
+	const bundleDir = path.join(
+		kdeBundle(tmpProjectRoot),
+		"look-and-feel",
+		"Ocean",
+	);
+	fs.mkdirSync(bundleDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(bundleDir, "metadata.json"),
+		'{"name":"Ocean","version":"1.0"}\n',
+	);
+	return bundleDir;
+}
+
+beforeEach(() => {
+	tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-kde-home-"));
+	tmpProjectRoot = fs.mkdtempSync(
+		path.join(os.tmpdir(), "haoshoku-kde-root-"),
+	);
+	fs.mkdirSync(path.join(tmpProjectRoot, "configs", "kde"), { recursive: true });
+});
+
+afterEach(() => {
+	fs.rmSync(tmpHome, { recursive: true, force: true });
+	fs.rmSync(tmpProjectRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Module shape
+// ---------------------------------------------------------------------------
+
+describe("configure_kde_theme module shape", () => {
+	it("exports backupKdeTheme, syncKdeTheme, configureKdeTheme", () => {
+		expect(typeof kdeTheme.backupKdeTheme).toBe("function");
+		expect(typeof kdeTheme.syncKdeTheme).toBe("function");
+		expect(typeof kdeTheme.configureKdeTheme).toBe("function");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// syncKdeTheme — FILE target → safeCopyFile (.bak behavior)
+// ---------------------------------------------------------------------------
+
+describe("syncKdeTheme — file target uses safeCopyFile (.bak behavior)", () => {
+	it("deploys a file component to the system path", async () => {
+		seedFileComponent(tmpProjectRoot);
+
+		await kdeTheme.syncKdeTheme({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const dest = path.join(
+			tmpHome,
+			".local",
+			"share",
+			"color-schemes",
+			"Ocean.colors",
+		);
+		expect(fs.existsSync(dest)).toBe(true);
+		expect(fs.readFileSync(dest, "utf8")).toContain("BackgroundNormal");
+	});
+
+	it("creates a .bak of a pre-existing file on first sync", async () => {
+		seedFileComponent(tmpProjectRoot);
+
+		// Pre-seed a different live file at the destination
+		const destDir = path.join(tmpHome, ".local", "share", "color-schemes");
+		fs.mkdirSync(destDir, { recursive: true });
+		const destFile = path.join(destDir, "Ocean.colors");
+		const ORIGINAL = "[Colors:Button]\nBackgroundNormal=0,0,0\n";
+		fs.writeFileSync(destFile, ORIGINAL);
+
+		await kdeTheme.syncKdeTheme({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const bakPath = `${destFile}.bak`;
+		expect(fs.existsSync(bakPath)).toBe(true);
+		expect(fs.readFileSync(bakPath, "utf8")).toBe(ORIGINAL);
+	});
+
+	it("preserves original .bak across two syncs (second run is no-op when content unchanged)", async () => {
+		seedFileComponent(tmpProjectRoot);
+
+		const destDir = path.join(tmpHome, ".local", "share", "color-schemes");
+		fs.mkdirSync(destDir, { recursive: true });
+		const destFile = path.join(destDir, "Ocean.colors");
+		const ORIGINAL = "[Colors:Button]\nBackgroundNormal=0,0,0\n";
+		fs.writeFileSync(destFile, ORIGINAL);
+
+		// First sync: backs up ORIGINAL → .bak, writes new content
+		await kdeTheme.syncKdeTheme({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		// Second sync: live matches bundle → no-op; .bak still holds the original
+		await kdeTheme.syncKdeTheme({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const bakPath = `${destFile}.bak`;
+		expect(fs.existsSync(bakPath)).toBe(true);
+		// .bak must NOT have been overwritten with the (now-current) content
+		expect(fs.readFileSync(bakPath, "utf8")).toBe(ORIGINAL);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// syncKdeTheme — DIRECTORY target → rename-to-.bak before copyDirRecursive
+// ---------------------------------------------------------------------------
+
+describe("syncKdeTheme — directory target renames existing dir to .bak", () => {
+	it("deploys a directory component to the system path", async () => {
+		seedDirComponent(tmpProjectRoot);
+
+		await kdeTheme.syncKdeTheme({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const dest = path.join(
+			tmpHome,
+			".local",
+			"share",
+			"plasma",
+			"look-and-feel",
+			"Ocean",
+		);
+		expect(fs.existsSync(dest)).toBe(true);
+		expect(
+			fs.existsSync(path.join(dest, "metadata.json")),
+		).toBe(true);
+	});
+
+	it("renames an existing dest dir to dest.bak before deploying", async () => {
+		seedDirComponent(tmpProjectRoot);
+
+		// Pre-seed an existing live directory at the destination
+		const dest = path.join(
+			tmpHome,
+			".local",
+			"share",
+			"plasma",
+			"look-and-feel",
+			"Ocean",
+		);
+		fs.mkdirSync(dest, { recursive: true });
+		fs.writeFileSync(
+			path.join(dest, "old-file.txt"),
+			"old content",
+		);
+
+		await kdeTheme.syncKdeTheme({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const bakPath = `${dest}.bak`;
+		expect(fs.existsSync(bakPath)).toBe(true);
+		expect(
+			fs.existsSync(path.join(bakPath, "old-file.txt")),
+		).toBe(true);
+		// New content deployed to dest
+		expect(
+			fs.existsSync(path.join(dest, "metadata.json")),
+		).toBe(true);
+	});
+
+	it("removes a stale .bak before renaming dest to .bak (fresh backup each sync)", async () => {
+		seedDirComponent(tmpProjectRoot);
+
+		const dest = path.join(
+			tmpHome,
+			".local",
+			"share",
+			"plasma",
+			"look-and-feel",
+			"Ocean",
+		);
+		// Seed the dest and a stale .bak
+		fs.mkdirSync(dest, { recursive: true });
+		fs.writeFileSync(path.join(dest, "current.txt"), "current");
+		const bakPath = `${dest}.bak`;
+		fs.mkdirSync(bakPath, { recursive: true });
+		fs.writeFileSync(path.join(bakPath, "stale.txt"), "stale");
+
+		await kdeTheme.syncKdeTheme({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		// Stale .bak is gone; new .bak holds what was in dest
+		expect(
+			fs.existsSync(path.join(bakPath, "stale.txt")),
+		).toBe(false);
+		expect(
+			fs.existsSync(path.join(bakPath, "current.txt")),
+		).toBe(true);
+	});
+
+	it("preserves original .bak across two syncs when dir content is already in sync", async () => {
+		seedDirComponent(tmpProjectRoot);
+
+		const dest = path.join(
+			tmpHome,
+			".local",
+			"share",
+			"plasma",
+			"look-and-feel",
+			"Ocean",
+		);
+
+		// Pre-seed an existing live directory with different content (the "original")
+		fs.mkdirSync(dest, { recursive: true });
+		fs.writeFileSync(path.join(dest, "original-file.txt"), "original user content");
+
+		// First sync: dest differs from bundle → dest renamed to .bak, bundle deployed
+		await kdeTheme.syncKdeTheme({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const bakPath = `${dest}.bak`;
+		// After run 1: .bak holds the original user dir
+		expect(fs.existsSync(bakPath)).toBe(true);
+		expect(fs.existsSync(path.join(bakPath, "original-file.txt"))).toBe(true);
+		// dest now holds bundle content
+		expect(fs.existsSync(path.join(dest, "metadata.json"))).toBe(true);
+
+		// Second sync: dest already holds bundle content → must be a no-op;
+		// .bak must still hold the original user dir, NOT the bundle content.
+		await kdeTheme.syncKdeTheme({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		expect(fs.existsSync(bakPath)).toBe(true);
+		// .bak must NOT have been overwritten with the (now-current) bundle content
+		expect(fs.existsSync(path.join(bakPath, "original-file.txt"))).toBe(true);
+		// The file that would appear if .bak was overwritten with bundle content:
+		expect(fs.existsSync(path.join(bakPath, "metadata.json"))).toBe(false);
+	});
+});

--- a/tests/configure_mimeapps.test.js
+++ b/tests/configure_mimeapps.test.js
@@ -270,6 +270,63 @@ describe("sync / backup round-trip", () => {
 });
 
 // ---------------------------------------------------------------------------
+// safeCopyFile integration — .bak preservation across runs
+// ---------------------------------------------------------------------------
+
+describe("syncMimeappsConfig — .bak backup behavior", () => {
+	it("creates a .bak of the live file on first sync (file had different content)", async () => {
+		// Seed a pre-existing live file with different content than repo
+		const ORIGINAL_LIVE = "[Default Applications]\ntext/html=firefox.desktop\n";
+		fs.mkdirSync(path.join(tmpHome, ".config"), { recursive: true });
+		fs.writeFileSync(
+			path.join(tmpHome, ".config", "mimeapps.list"),
+			ORIGINAL_LIVE,
+		);
+		seedRepoMimeapps();
+
+		await mimeapps.syncMimeappsConfig({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const bakPath = path.join(tmpHome, ".config", "mimeapps.list.bak");
+		expect(fs.existsSync(bakPath)).toBe(true);
+		expect(fs.readFileSync(bakPath, "utf8")).toBe(ORIGINAL_LIVE);
+		// live file is now the repo version
+		expect(
+			fs.readFileSync(path.join(tmpHome, ".config", "mimeapps.list"), "utf8"),
+		).toBe(FIXTURE_CONTENT);
+	});
+
+	it("preserves original .bak across two syncs (second run is no-op when content unchanged)", async () => {
+		const ORIGINAL_LIVE = "[Default Applications]\ntext/html=firefox.desktop\n";
+		fs.mkdirSync(path.join(tmpHome, ".config"), { recursive: true });
+		fs.writeFileSync(
+			path.join(tmpHome, ".config", "mimeapps.list"),
+			ORIGINAL_LIVE,
+		);
+		seedRepoMimeapps();
+
+		// First sync: writes FIXTURE_CONTENT, backs up ORIGINAL_LIVE → .bak
+		await mimeapps.syncMimeappsConfig({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		// Second sync: live already matches repo → no-op; .bak still holds the original
+		await mimeapps.syncMimeappsConfig({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const bakPath = path.join(tmpHome, ".config", "mimeapps.list.bak");
+		expect(fs.existsSync(bakPath)).toBe(true);
+		// .bak must still be the ORIGINAL — not overwritten with FIXTURE_CONTENT
+		expect(fs.readFileSync(bakPath, "utf8")).toBe(ORIGINAL_LIVE);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // configureMimeapps — alias for syncMimeappsConfig
 // ---------------------------------------------------------------------------
 

--- a/tests/configure_zed.test.js
+++ b/tests/configure_zed.test.js
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+
+import {
+	backupZedConfig,
+	syncZedConfig,
+	syncZedTheme,
+} from "../src/helpers/configure_zed.js";
 
 const PROJECT_ROOT = path.resolve(__dirname, "..");
 const ZED_CONFIG_DIR = path.join(PROJECT_ROOT, "configs", "zed");
@@ -28,5 +35,353 @@ describe("Zed Caelestia theme defaults", () => {
 		const style = theme.themes[0].style;
 		expect(style["editor.background"]).toMatch(/^#[0-9a-fA-F]{6,8}$/);
 		expect(style["border.focused"]).toMatch(/^#[0-9a-fA-F]{6,8}$/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Behavioral tests — injectable tmp dirs (never touch real $HOME / repo)
+// ---------------------------------------------------------------------------
+
+let tmpZedConfigDir;
+let tmpBackupDir;
+
+beforeEach(() => {
+	tmpZedConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-zed-live-"));
+	tmpBackupDir = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-zed-backup-"));
+});
+
+afterEach(() => {
+	fs.rmSync(tmpZedConfigDir, { recursive: true, force: true });
+	fs.rmSync(tmpBackupDir, { recursive: true, force: true });
+});
+
+/** Seed a live settings.json with the given object/string. */
+function seedLiveSettings(content) {
+	const body = typeof content === "string" ? content : JSON.stringify(content, null, 2);
+	fs.writeFileSync(path.join(tmpZedConfigDir, "settings.json"), body);
+}
+
+/** Read the backed-up sanitized settings.json as a parsed object. */
+function readBackupSettings() {
+	const raw = fs.readFileSync(path.join(tmpBackupDir, "settings.json"), "utf8");
+	return JSON.parse(raw);
+}
+
+describe("backupZedConfig — deep sanitization", () => {
+	it("strips top-level ssh_connections", async () => {
+		seedLiveSettings({
+			theme: "Caelestia",
+			ssh_connections: [{ host: "box", username: "me" }],
+		});
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		expect(out.ssh_connections).toBeUndefined();
+		expect(out.theme).toBe("Caelestia");
+	});
+
+	it("strips a nested token at any depth", async () => {
+		seedLiveSettings({
+			language_models: {
+				openai_compatible: {
+					NVIDIA: {
+						api_url: "https://example.com/v1",
+						api_key: "sk-secret-should-be-gone",
+					},
+				},
+			},
+		});
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		const nvidia = out.language_models.openai_compatible.NVIDIA;
+		expect(nvidia.api_key).toBeUndefined();
+		// Sibling non-sensitive key survives.
+		expect(nvidia.api_url).toBe("https://example.com/v1");
+	});
+
+	it("strips a deeply nested 'token' key inside an array element", async () => {
+		seedLiveSettings({
+			servers: [
+				{ name: "a", token: "leak-me" },
+				{ name: "b", config: { bearer: "also-leak" } },
+			],
+		});
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		expect(out.servers[0].token).toBeUndefined();
+		expect(out.servers[0].name).toBe("a");
+		expect(out.servers[1].config.bearer).toBeUndefined();
+		expect(out.servers[1].name).toBe("b");
+	});
+
+	it("strips an 'env' object under context_servers (MCP token block)", async () => {
+		seedLiveSettings({
+			context_servers: {
+				my_mcp: {
+					command: "node",
+					args: ["server.js"],
+					env: { GITHUB_TOKEN: "ghp_secret", FOO: "bar" },
+				},
+			},
+		});
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		const server = out.context_servers.my_mcp;
+		expect(server.env).toBeUndefined();
+		// Non-sensitive siblings survive.
+		expect(server.command).toBe("node");
+		expect(server.args).toEqual(["server.js"]);
+	});
+
+	it("keeps non-sensitive keys like api_url, keymap, signing", async () => {
+		seedLiveSettings({
+			api_url: "https://api.example.com",
+			keymap: "vim",
+			signing: true,
+		});
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		expect(out.api_url).toBe("https://api.example.com");
+		expect(out.keymap).toBe("vim");
+		expect(out.signing).toBe(true);
+	});
+
+	it("matches credential/access_key/private_key/passw variants", async () => {
+		seedLiveSettings({
+			my_credential: "x",
+			access_key: "y",
+			"private-key": "z",
+			password: "p",
+			my_secret: "s",
+			apikey: "k",
+			keep_me: "ok",
+		});
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		expect(out.my_credential).toBeUndefined();
+		expect(out.access_key).toBeUndefined();
+		expect(out["private-key"]).toBeUndefined();
+		expect(out.password).toBeUndefined();
+		expect(out.my_secret).toBeUndefined();
+		expect(out.apikey).toBeUndefined();
+		expect(out.keep_me).toBe("ok");
+	});
+});
+
+describe("backupZedConfig — tolerant JSONC parsing", () => {
+	it("parses inline // comments and trailing commas", async () => {
+		seedLiveSettings(
+			[
+				"{",
+				'  "theme": "Caelestia", // my favorite',
+				'  "autosave": "on_focus_change",',
+				"  // a whole-line comment",
+				'  "git_panel": { "dock": "right", },',
+				"}",
+			].join("\n"),
+		);
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		expect(out.theme).toBe("Caelestia");
+		expect(out.autosave).toBe("on_focus_change");
+		expect(out.git_panel.dock).toBe("right");
+	});
+
+	it("parses /* block */ comments and does not strip // inside strings", async () => {
+		seedLiveSettings(
+			[
+				"{",
+				"  /* block comment */",
+				'  "api_url": "https://example.com/v1", // keep this url',
+				'  "note": "protocol is https://not-a-comment",',
+				"}",
+			].join("\n"),
+		);
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		expect(out.api_url).toBe("https://example.com/v1");
+		expect(out.note).toBe("protocol is https://not-a-comment");
+	});
+
+	it("does not corrupt string values that contain ',}' or ',]'", async () => {
+		// The trailing-comma strip must be string-literal aware: a value that
+		// literally contains ",}" / ",]" is data, not syntax, and must survive
+		// the JSONC → JSON normalization untouched.
+		seedLiveSettings({
+			note: "trailing,}here",
+			list_note: "bracket,]case",
+			// A real trailing comma in structural position still gets stripped.
+			git_panel: { dock: "right" },
+		});
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		expect(out.note).toBe("trailing,}here");
+		expect(out.list_note).toBe("bracket,]case");
+		expect(out.git_panel.dock).toBe("right");
+	});
+
+	it("does not crash on malformed JSON; continues backing up the rest", async () => {
+		// Unparseable settings.json
+		seedLiveSettings("{ this is : not json ]");
+		// A valid keymap should still get backed up.
+		fs.writeFileSync(
+			path.join(tmpZedConfigDir, "keymap.json"),
+			'[{"context":"Editor"}]',
+		);
+
+		await expect(
+			backupZedConfig({
+				zedConfigDir: tmpZedConfigDir,
+				backupDir: tmpBackupDir,
+			}),
+		).resolves.toBeUndefined();
+
+		// settings.json was skipped, keymap.json still backed up.
+		expect(fs.existsSync(path.join(tmpBackupDir, "settings.json"))).toBe(false);
+		expect(fs.existsSync(path.join(tmpBackupDir, "keymap.json"))).toBe(true);
+	});
+});
+
+describe("syncZedConfig / syncZedTheme — safeCopyFile backups", () => {
+	/** Seed the repo backup dir with a settings.json + keymap.json + theme. */
+	function seedBackup() {
+		fs.writeFileSync(
+			path.join(tmpBackupDir, "settings.json"),
+			'{\n  "theme": "Caelestia"\n}',
+		);
+		fs.writeFileSync(
+			path.join(tmpBackupDir, "keymap.json"),
+			'[{"context":"Editor"}]',
+		);
+		fs.mkdirSync(path.join(tmpBackupDir, "themes"), { recursive: true });
+		fs.writeFileSync(
+			path.join(tmpBackupDir, "themes", "caelestia.json"),
+			'{"name":"Caelestia"}',
+		);
+	}
+
+	it("backs up an existing live settings.json to .bak before overwriting", async () => {
+		seedBackup();
+		// Live file has different content → should be backed up.
+		fs.writeFileSync(
+			path.join(tmpZedConfigDir, "settings.json"),
+			'{\n  "theme": "OldUserTheme"\n}',
+		);
+
+		await syncZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const bak = path.join(tmpZedConfigDir, "settings.json.bak");
+		expect(fs.existsSync(bak)).toBe(true);
+		expect(fs.readFileSync(bak, "utf8")).toContain("OldUserTheme");
+		// Live now matches repo.
+		expect(
+			fs.readFileSync(path.join(tmpZedConfigDir, "settings.json"), "utf8"),
+		).toContain("Caelestia");
+	});
+
+	it("second sync run leaves the first .bak intact (identical content skips)", async () => {
+		seedBackup();
+		fs.writeFileSync(
+			path.join(tmpZedConfigDir, "settings.json"),
+			'{\n  "theme": "OldUserTheme"\n}',
+		);
+
+		await syncZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+		const bakAfterFirst = fs.readFileSync(
+			path.join(tmpZedConfigDir, "settings.json.bak"),
+			"utf8",
+		);
+
+		// Second run: live == repo now, so safeCopyFile should skip and not
+		// clobber the original .bak.
+		await syncZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+		const bakAfterSecond = fs.readFileSync(
+			path.join(tmpZedConfigDir, "settings.json.bak"),
+			"utf8",
+		);
+
+		expect(bakAfterSecond).toBe(bakAfterFirst);
+		expect(bakAfterSecond).toContain("OldUserTheme");
+	});
+
+	it("syncZedTheme backs up an existing live theme before overwriting", async () => {
+		fs.mkdirSync(path.join(tmpBackupDir, "themes"), { recursive: true });
+		fs.writeFileSync(
+			path.join(tmpBackupDir, "themes", "caelestia.json"),
+			'{"name":"Caelestia","v":2}',
+		);
+		fs.mkdirSync(path.join(tmpZedConfigDir, "themes"), { recursive: true });
+		fs.writeFileSync(
+			path.join(tmpZedConfigDir, "themes", "caelestia.json"),
+			'{"name":"Caelestia","v":1}',
+		);
+
+		await syncZedTheme({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const bak = path.join(tmpZedConfigDir, "themes", "caelestia.json.bak");
+		expect(fs.existsSync(bak)).toBe(true);
+		expect(fs.readFileSync(bak, "utf8")).toContain('"v":1');
+		expect(
+			fs.readFileSync(
+				path.join(tmpZedConfigDir, "themes", "caelestia.json"),
+				"utf8",
+			),
+		).toContain('"v":2');
 	});
 });

--- a/tests/configure_zed.test.js
+++ b/tests/configure_zed.test.js
@@ -195,6 +195,72 @@ describe("backupZedConfig — deep sanitization", () => {
 		expect(out.apikey).toBeUndefined();
 		expect(out.keep_me).toBe("ok");
 	});
+
+	it("strips headers.Authorization bearer tokens (PR #8 review C1)", async () => {
+		seedLiveSettings({
+			context_servers: {
+				my_api: {
+					url: "https://example.com/mcp",
+					headers: { Authorization: "Bearer SUPERSECRET123" },
+				},
+			},
+		});
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		const server = out.context_servers.my_api;
+		expect(server.headers?.Authorization).toBeUndefined();
+		expect(server.url).toBe("https://example.com/mcp");
+		// The raw backup file must not contain the token anywhere.
+		expect(JSON.stringify(out)).not.toContain("SUPERSECRET123");
+	});
+
+	it("strips Proxy-Authorization and an 'authorization' key outside headers", async () => {
+		seedLiveSettings({
+			headers: { "Proxy-Authorization": "Basic dXNlcjpwYXNz" },
+			authorization: "Bearer top-level-leak",
+			keep_me: "ok",
+		});
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		expect(out.headers?.["Proxy-Authorization"]).toBeUndefined();
+		expect(out.authorization).toBeUndefined();
+		expect(out.keep_me).toBe("ok");
+	});
+
+	it("strips auth-scheme values under headers even with benign key names", async () => {
+		seedLiveSettings({
+			headers: {
+				"X-Custom": "Bearer sneaky-token",
+				"X-Other": "Basic dXNlcjpwYXNz",
+				Cookie: "session=abc123",
+				"Content-Type": "application/json",
+				Accept: "application/json",
+			},
+		});
+
+		await backupZedConfig({
+			zedConfigDir: tmpZedConfigDir,
+			backupDir: tmpBackupDir,
+		});
+
+		const out = readBackupSettings();
+		expect(out.headers["X-Custom"]).toBeUndefined();
+		expect(out.headers["X-Other"]).toBeUndefined();
+		expect(out.headers.Cookie).toBeUndefined();
+		// Benign headers survive.
+		expect(out.headers["Content-Type"]).toBe("application/json");
+		expect(out.headers.Accept).toBe("application/json");
+	});
 });
 
 describe("backupZedConfig — tolerant JSONC parsing", () => {

--- a/tests/debian_server.test.js
+++ b/tests/debian_server.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildFail2banJail,
+	setupFirewall,
+} from "../src/os_scripts/debian_server.js";
+
+// A fake `run` that records every command it sees and returns a configured
+// result per command substring. Defaults to `true` (success) for any command
+// not explicitly mapped.
+function makeFakeRun(overrides = {}) {
+	const calls = [];
+	const run = async (command) => {
+		calls.push(command);
+		for (const [needle, result] of Object.entries(overrides)) {
+			if (command.includes(needle)) return result;
+		}
+		return true;
+	};
+	return { run, calls };
+}
+
+function makeFakePrompt(value = true) {
+	const calls = [];
+	const prompt = async (message) => {
+		calls.push(message);
+		return value;
+	};
+	return { prompt, calls };
+}
+
+describe("buildFail2banJail", () => {
+	const jail = buildFail2banJail();
+
+	it("declares the [sshd] jail block", () => {
+		expect(jail).toContain("[sshd]");
+	});
+
+	it("uses the systemd backend (Debian 12+ has no rsyslog/auth.log by default)", () => {
+		expect(jail).toMatch(/^\s*backend\s*=\s*systemd\s*$/m);
+	});
+
+	it("keeps logpath = /var/log/auth.log (systemd backend ignores it)", () => {
+		expect(jail).toMatch(/logpath\s*=\s*\/var\/log\/auth\.log/);
+	});
+
+	it("enables the jail", () => {
+		expect(jail).toMatch(/enabled\s*=\s*true/);
+	});
+
+	it("is a pure function — repeated calls return identical content", () => {
+		expect(buildFail2banJail()).toBe(jail);
+	});
+});
+
+describe("setupFirewall (UFW lockout gate)", () => {
+	it("does NOT enable UFW when the SSH allow rule fails (remote lockout risk)", async () => {
+		const { run, calls } = makeFakeRun({ "ufw allow ssh": false });
+		const { prompt, calls: promptCalls } = makeFakePrompt(true);
+
+		await setupFirewall({ run, prompt });
+
+		expect(calls.some((c) => c.includes("ufw enable"))).toBe(false);
+		// It must not even reach the enable prompt.
+		expect(promptCalls.length).toBe(0);
+	});
+
+	it("enables UFW when all rules succeed and the user confirms", async () => {
+		const { run, calls } = makeFakeRun();
+		const { prompt, calls: promptCalls } = makeFakePrompt(true);
+
+		await setupFirewall({ run, prompt });
+
+		expect(promptCalls.length).toBe(1);
+		expect(calls.some((c) => c.includes("ufw enable"))).toBe(true);
+	});
+
+	it("does NOT enable UFW when rules succeed but the user declines", async () => {
+		const { run, calls } = makeFakeRun();
+		const { prompt } = makeFakePrompt(false);
+
+		await setupFirewall({ run, prompt });
+
+		expect(calls.some((c) => c.includes("ufw enable"))).toBe(false);
+	});
+
+	it("runs the SSH allow rule before deciding to enable", async () => {
+		const { run, calls } = makeFakeRun();
+		const { prompt } = makeFakePrompt(true);
+
+		await setupFirewall({ run, prompt });
+
+		expect(calls.some((c) => c.includes("ufw allow ssh"))).toBe(true);
+	});
+});

--- a/tests/install_user_scripts.test.js
+++ b/tests/install_user_scripts.test.js
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import * as userScripts from "../src/helpers/install_user_scripts.js";
+
+let tmpHome;
+let tmpProjectRoot;
+
+function scriptsSrcDir(tmpProjectRoot) {
+	return path.join(tmpProjectRoot, "configs", "scripts");
+}
+
+function seedScript(tmpProjectRoot, name, content = "#!/bin/sh\necho hi\n") {
+	const dir = scriptsSrcDir(tmpProjectRoot);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, name), content);
+}
+
+beforeEach(() => {
+	tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-scripts-home-"));
+	tmpProjectRoot = fs.mkdtempSync(
+		path.join(os.tmpdir(), "haoshoku-scripts-root-"),
+	);
+});
+
+afterEach(() => {
+	fs.rmSync(tmpHome, { recursive: true, force: true });
+	fs.rmSync(tmpProjectRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Module shape
+// ---------------------------------------------------------------------------
+
+describe("install_user_scripts module shape", () => {
+	it("exports installUserScripts as a function", () => {
+		expect(typeof userScripts.installUserScripts).toBe("function");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// installUserScripts — basic deployment
+// ---------------------------------------------------------------------------
+
+describe("installUserScripts — deployment", () => {
+	it("copies scripts to ~/.local/bin/", async () => {
+		seedScript(tmpProjectRoot, "my-tool");
+
+		await userScripts.installUserScripts({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const dest = path.join(tmpHome, ".local", "bin", "my-tool");
+		expect(fs.existsSync(dest)).toBe(true);
+		expect(fs.readFileSync(dest, "utf8")).toContain("echo hi");
+	});
+
+	it("sets chmod 755 on deployed scripts", async () => {
+		seedScript(tmpProjectRoot, "my-tool");
+
+		await userScripts.installUserScripts({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const dest = path.join(tmpHome, ".local", "bin", "my-tool");
+		const mode = fs.statSync(dest).mode;
+		// Check owner, group, other exec bits
+		expect(mode & 0o111).toBe(0o111);
+	});
+
+	it("creates ~/.local/bin/ if it does not exist", async () => {
+		seedScript(tmpProjectRoot, "my-tool");
+
+		expect(fs.existsSync(path.join(tmpHome, ".local", "bin"))).toBe(false);
+
+		await userScripts.installUserScripts({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		expect(fs.existsSync(path.join(tmpHome, ".local", "bin"))).toBe(true);
+	});
+
+	it("skips hidden files (dot-files like .gitkeep)", async () => {
+		seedScript(tmpProjectRoot, "real-tool");
+		const dir = scriptsSrcDir(tmpProjectRoot);
+		fs.writeFileSync(path.join(dir, ".gitkeep"), "");
+
+		await userScripts.installUserScripts({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const localBin = path.join(tmpHome, ".local", "bin");
+		expect(fs.existsSync(path.join(localBin, ".gitkeep"))).toBe(false);
+		expect(fs.existsSync(path.join(localBin, "real-tool"))).toBe(true);
+	});
+
+	it("is a no-op (no error) when configs/scripts/ does not exist", async () => {
+		// No seedScript — source dir absent
+		await expect(
+			userScripts.installUserScripts({
+				home: tmpHome,
+				projectRoot: tmpProjectRoot,
+			}),
+		).resolves.toBeUndefined();
+
+		expect(
+			fs.existsSync(path.join(tmpHome, ".local", "bin")),
+		).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// installUserScripts — .bak backup behavior via safeCopyFile
+// ---------------------------------------------------------------------------
+
+describe("installUserScripts — .bak behavior for pre-existing different files", () => {
+	it("creates a .bak of a pre-existing file with different content", async () => {
+		seedScript(tmpProjectRoot, "my-tool", "#!/bin/sh\necho new\n");
+
+		// Pre-seed a different version at the destination
+		const localBin = path.join(tmpHome, ".local", "bin");
+		fs.mkdirSync(localBin, { recursive: true });
+		const destFile = path.join(localBin, "my-tool");
+		const ORIGINAL = "#!/bin/sh\necho old\n";
+		fs.writeFileSync(destFile, ORIGINAL);
+
+		await userScripts.installUserScripts({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const bakPath = `${destFile}.bak`;
+		expect(fs.existsSync(bakPath)).toBe(true);
+		expect(fs.readFileSync(bakPath, "utf8")).toBe(ORIGINAL);
+		// New content deployed
+		expect(fs.readFileSync(destFile, "utf8")).toContain("echo new");
+	});
+
+	it("does not create a .bak and does not change the file when content is unchanged (second run)", async () => {
+		seedScript(tmpProjectRoot, "my-tool", "#!/bin/sh\necho hi\n");
+
+		await userScripts.installUserScripts({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		// First run may have created a .bak (it won't — no pre-existing file), ensure none exists
+		const destFile = path.join(tmpHome, ".local", "bin", "my-tool");
+		const bakPath = `${destFile}.bak`;
+		expect(fs.existsSync(bakPath)).toBe(false);
+
+		// Record mtime before second run
+		const mtimeBefore = fs.statSync(destFile).mtimeMs;
+
+		// Small delay to ensure mtime would differ if re-written
+		await new Promise((r) => setTimeout(r, 20));
+
+		// Second run — identical content; safeCopyFile should no-op
+		await userScripts.installUserScripts({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const mtimeAfter = fs.statSync(destFile).mtimeMs;
+		// File not re-written (mtime unchanged)
+		expect(mtimeAfter).toBe(mtimeBefore);
+		// Still no .bak
+		expect(fs.existsSync(bakPath)).toBe(false);
+	});
+
+	it("preserves original .bak across two syncs (second run is no-op when content same as repo)", async () => {
+		const NEW_CONTENT = "#!/bin/sh\necho new\n";
+		seedScript(tmpProjectRoot, "my-tool", NEW_CONTENT);
+
+		const localBin = path.join(tmpHome, ".local", "bin");
+		fs.mkdirSync(localBin, { recursive: true });
+		const destFile = path.join(localBin, "my-tool");
+		const ORIGINAL = "#!/bin/sh\necho old\n";
+		fs.writeFileSync(destFile, ORIGINAL);
+
+		// First sync: backs up ORIGINAL → .bak, writes NEW_CONTENT
+		await userScripts.installUserScripts({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		// Second sync: live already matches repo → no-op; .bak still holds ORIGINAL
+		await userScripts.installUserScripts({
+			home: tmpHome,
+			projectRoot: tmpProjectRoot,
+		});
+
+		const bakPath = `${destFile}.bak`;
+		expect(fs.existsSync(bakPath)).toBe(true);
+		// .bak must NOT be overwritten with current content
+		expect(fs.readFileSync(bakPath, "utf8")).toBe(ORIGINAL);
+	});
+});

--- a/tests/release.test.js
+++ b/tests/release.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { applyVersionBump, computeNextVersion } from "../scripts/release.js";
+
+describe("computeNextVersion", () => {
+	it("bumps the patch component", () => {
+		expect(computeNextVersion("5.5.3", "patch")).toBe("5.5.4");
+		expect(computeNextVersion("5.5.9", "patch")).toBe("5.5.10");
+	});
+
+	it("bumps the minor component and resets patch", () => {
+		expect(computeNextVersion("5.5.3", "minor")).toBe("5.6.0");
+		expect(computeNextVersion("5.0.7", "minor")).toBe("5.1.0");
+	});
+
+	it("bumps the major component and resets minor and patch", () => {
+		expect(computeNextVersion("5.5.3", "major")).toBe("6.0.0");
+		expect(computeNextVersion("0.9.9", "major")).toBe("1.0.0");
+	});
+
+	it("returns the explicit version for a custom bump", () => {
+		expect(computeNextVersion("5.5.3", "custom", "9.1.2")).toBe("9.1.2");
+	});
+
+	it("throws on a malformed current version", () => {
+		expect(() => computeNextVersion("5.x", "patch")).toThrow(/Invalid/);
+		expect(() => computeNextVersion("5.5", "minor")).toThrow(/Invalid/);
+		expect(() => computeNextVersion("", "major")).toThrow(/Invalid/);
+		expect(() => computeNextVersion(undefined, "patch")).toThrow(/Invalid/);
+	});
+
+	it("throws on a custom bump with a malformed explicit version", () => {
+		expect(() => computeNextVersion("5.5.3", "custom", "9.1")).toThrow(/Invalid/);
+		expect(() => computeNextVersion("5.5.3", "custom", "5.6.0-rc1")).toThrow(/Invalid/);
+	});
+
+	it("throws on an unknown bump type", () => {
+		expect(() => computeNextVersion("5.5.3", "nope")).toThrow();
+	});
+});
+
+describe("applyVersionBump", () => {
+	it("replaces exactly one .version(...) site", () => {
+		const content = 'program\n  .name("haoshoku")\n  .version("5.5.3")\n  .parse();\n';
+		const updated = applyVersionBump(content, "5.6.0");
+		expect(updated).toContain('.version("5.6.0")');
+		expect(updated).not.toContain('.version("5.5.3")');
+		// Only one occurrence of the new version string.
+		expect(updated.split('.version("5.6.0")').length - 1).toBe(1);
+	});
+
+	it("throws when the .version(...) pattern is not found", () => {
+		const content = 'program\n  .name("haoshoku")\n  .parse();\n';
+		expect(() => applyVersionBump(content, "5.6.0")).toThrow(
+			/version pattern not found/,
+		);
+	});
+});

--- a/tests/skill_manager.test.js
+++ b/tests/skill_manager.test.js
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { syncSkills } from "../src/helpers/skill_manager.js";
+import {
+	mergeSkills,
+	resolveDefaultBranch,
+	syncSkills,
+} from "../src/helpers/skill_manager.js";
 
 describe("syncSkills()", () => {
 	let tmpDir;
@@ -47,5 +51,199 @@ describe("syncSkills()", () => {
 
 		expect(result).toEqual({ status: "all-failed", merged: 0 });
 		expect(exitSpy).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// symlinkSharedResource — tested via mergeSkills
+// ---------------------------------------------------------------------------
+describe("mergeSkills() — symlinkSharedResource safe-backup", () => {
+	let tmpDir;
+	let skillsDestDir;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-merge-"));
+		skillsDestDir = path.join(tmpDir, "dest-skills");
+		fs.mkdirSync(skillsDestDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	/**
+	 * Build a minimal fake source layout that mergeSkills expects:
+	 *   <cacheRoot>/skills/scripts/
+	 *   <cacheRoot>/skills/CLAUDE.md
+	 *   <cacheRoot>/skills/README.md
+	 */
+	function buildFakeSource(name) {
+		const cacheRoot = path.join(tmpDir, `cache-${name}`);
+		const skillsRoot = path.join(cacheRoot, "skills");
+		fs.mkdirSync(path.join(skillsRoot, "scripts"), { recursive: true });
+		fs.writeFileSync(
+			path.join(skillsRoot, "scripts", "helper.sh"),
+			"#!/bin/sh\n",
+		);
+		fs.writeFileSync(path.join(skillsRoot, "CLAUDE.md"), `# ${name}\n`);
+		fs.writeFileSync(path.join(skillsRoot, "README.md"), `# readme ${name}\n`);
+		return { url: `https://github.com/owner/${name}`, name, cachePath: cacheRoot };
+	}
+
+	it("backs up a pre-existing real directory to .bak and replaces with symlink", () => {
+		// Put a REAL directory at the scripts destination before mergeSkills runs.
+		const destScripts = path.join(skillsDestDir, "scripts");
+		fs.mkdirSync(destScripts, { recursive: true });
+		fs.writeFileSync(path.join(destScripts, "existing.sh"), "old content\n");
+
+		const source = buildFakeSource("repo-a");
+
+		// Patch CLAUDE_SKILLS_DIR to our tmp directory.
+		mergeSkills([source], { skillsDir: skillsDestDir });
+
+		// The original real directory must survive as .bak
+		const bakPath = `${destScripts}.bak`;
+		expect(fs.existsSync(bakPath)).toBe(true);
+		const bakStat = fs.lstatSync(bakPath);
+		expect(bakStat.isDirectory()).toBe(true);
+		// The file that was inside must still be there
+		expect(fs.existsSync(path.join(bakPath, "existing.sh"))).toBe(true);
+
+		// The destination must now be a symlink
+		const destStat = fs.lstatSync(destScripts);
+		expect(destStat.isSymbolicLink()).toBe(true);
+		// Pointing to the cache source
+		const srcScripts = path.join(source.cachePath, "skills", "scripts");
+		expect(fs.readlinkSync(destScripts)).toBe(srcScripts);
+	});
+
+	it("backs up a pre-existing real file to .bak and replaces with symlink", () => {
+		// Put a REAL file at the CLAUDE.md destination before mergeSkills runs.
+		const destClaudeMd = path.join(skillsDestDir, "CLAUDE.md");
+		fs.writeFileSync(destClaudeMd, "old CLAUDE content\n");
+
+		const source = buildFakeSource("repo-b");
+
+		mergeSkills([source], { skillsDir: skillsDestDir });
+
+		const bakPath = `${destClaudeMd}.bak`;
+		expect(fs.existsSync(bakPath)).toBe(true);
+		const bakStat = fs.lstatSync(bakPath);
+		expect(bakStat.isFile()).toBe(true);
+
+		const destStat = fs.lstatSync(destClaudeMd);
+		expect(destStat.isSymbolicLink()).toBe(true);
+	});
+
+	it("removes a stale .bak before renaming, then renames existing real dir", () => {
+		// Pre-existing REAL dir AND stale .bak
+		const destScripts = path.join(skillsDestDir, "scripts");
+		fs.mkdirSync(destScripts, { recursive: true });
+		fs.writeFileSync(path.join(destScripts, "existing.sh"), "content\n");
+
+		const bakPath = `${destScripts}.bak`;
+		// Stale .bak is itself a directory
+		fs.mkdirSync(bakPath, { recursive: true });
+		fs.writeFileSync(path.join(bakPath, "stale.sh"), "stale\n");
+
+		const source = buildFakeSource("repo-c");
+
+		// Should not throw even though .bak already exists
+		expect(() => mergeSkills([source], { skillsDir: skillsDestDir })).not.toThrow();
+
+		// .bak now holds the formerly-live directory (stale one wiped)
+		expect(fs.existsSync(bakPath)).toBe(true);
+		expect(fs.existsSync(path.join(bakPath, "existing.sh"))).toBe(true);
+
+		// dest is symlink
+		const destStat = fs.lstatSync(destScripts);
+		expect(destStat.isSymbolicLink()).toBe(true);
+	});
+
+	it("re-symlinks an existing symlink that points to the wrong target (no .bak)", () => {
+		const destScripts = path.join(skillsDestDir, "scripts");
+		// Wrong symlink pointing to non-existent path
+		fs.symlinkSync("/tmp/wrong-target", destScripts);
+
+		const source = buildFakeSource("repo-d");
+
+		mergeSkills([source], { skillsDir: skillsDestDir });
+
+		// No .bak should be created for a symlink
+		expect(fs.existsSync(`${destScripts}.bak`)).toBe(false);
+
+		const destStat = fs.lstatSync(destScripts);
+		expect(destStat.isSymbolicLink()).toBe(true);
+		const srcScripts = path.join(source.cachePath, "skills", "scripts");
+		expect(fs.readlinkSync(destScripts)).toBe(srcScripts);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// resolveDefaultBranch
+// ---------------------------------------------------------------------------
+describe("resolveDefaultBranch()", () => {
+	let tmpDir;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-branch-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	/** Skip the test gracefully if git is not available in this environment. */
+	function requireGit() {
+		const result = Bun.spawnSync(["git", "--version"]);
+		if (result.exitCode !== 0) {
+			console.log("SKIP: git not available");
+			return false;
+		}
+		return true;
+	}
+
+	it("resolves 'master' from a repo whose default branch is master", async () => {
+		if (!requireGit()) return;
+
+		// Create a bare "origin" repo with a master branch
+		const originPath = path.join(tmpDir, "origin.git");
+		const localPath = path.join(tmpDir, "local");
+
+		// Init bare repo with -b master
+		const initResult = Bun.spawnSync(
+			["git", "init", "--bare", "-b", "master", originPath],
+		);
+		if (initResult.exitCode !== 0) {
+			// Older git may not support -b; skip
+			console.log("SKIP: git init -b not supported");
+			return;
+		}
+
+		// Create a local clone with an initial commit so origin/HEAD can be set
+		Bun.spawnSync(["git", "clone", originPath, localPath]);
+		// Need at least one commit for origin/HEAD to be meaningful
+		Bun.spawnSync(["git", "-C", localPath, "config", "user.email", "test@test.com"]);
+		Bun.spawnSync(["git", "-C", localPath, "config", "user.name", "Test"]);
+		Bun.spawnSync(["git", "-C", localPath, "commit", "--allow-empty", "-m", "init"]);
+		Bun.spawnSync(["git", "-C", localPath, "push", "origin", "master"]);
+
+		// Set origin/HEAD on the bare repo
+		Bun.spawnSync(["git", "-C", originPath, "symbolic-ref", "HEAD", "refs/heads/master"]);
+
+		// Now set remote set-head on local
+		Bun.spawnSync(["git", "-C", localPath, "remote", "set-head", "origin", "--auto"]);
+
+		const branch = resolveDefaultBranch(localPath);
+		expect(branch).toBe("master");
+	});
+
+	it("falls back to 'main' when git is not a repo / branch cannot be resolved", () => {
+		// Non-git directory — should not throw, should return 'main'
+		const nonRepo = path.join(tmpDir, "not-a-repo");
+		fs.mkdirSync(nonRepo);
+
+		const branch = resolveDefaultBranch(nonRepo);
+		expect(branch).toBe("main");
 	});
 });

--- a/tests/superpowers.test.js
+++ b/tests/superpowers.test.js
@@ -51,4 +51,26 @@ describe("installSuperpowers()", () => {
 		await expect(installSuperpowers(settingsPath)).resolves.toBeUndefined();
 		expect(fs.existsSync(settingsPath)).toBe(false);
 	});
+
+	it("returns without throwing when settings.json is not valid JSON", async () => {
+		const malformed = "{ enabledPlugins: not valid json";
+		fs.writeFileSync(settingsPath, malformed);
+
+		const messages = [];
+		const originalError = console.error;
+		console.error = (...args) => messages.push(args.join(" "));
+		try {
+			await expect(
+				installSuperpowers(settingsPath),
+			).resolves.toBeUndefined();
+		} finally {
+			console.error = originalError;
+		}
+
+		// File is left untouched (no partial write / stub).
+		expect(fs.readFileSync(settingsPath, "utf-8")).toBe(malformed);
+		// A clear, actionable error was logged.
+		expect(messages.join("\n")).toMatch(/settings\.json is not valid JSON/i);
+		expect(messages.join("\n")).toMatch(/haoshoku --claude/);
+	});
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import {
 	commandExists,
+	copyDirRecursive,
+	promptUser,
 	readConfiguredDeviceType,
 	readDeviceType,
 	runCommand,
@@ -27,6 +29,23 @@ describe("Utils", () => {
 	// However, we can test that it runs a simple echo command.
 	it("runCommand executes successfully", async () => {
 		const result = await runCommand("echo 'test'", { check: false });
+		expect(result).toBe(true);
+	});
+
+	it("runCommand runs a plain (non-shell) command", async () => {
+		const result = await runCommand("true", { check: false });
+		expect(result).toBe(true);
+	});
+
+	it("runCommand fails when an EARLY pipeline stage fails (pipefail)", async () => {
+		// POSIX sh would report only `cat`'s exit (0); pipefail must surface
+		// the failing `false`.
+		const result = await runCommand("false | cat", { check: false });
+		expect(result).toBe(false);
+	});
+
+	it("runCommand succeeds when every pipeline stage succeeds", async () => {
+		const result = await runCommand("echo ok | cat", { check: false });
 		expect(result).toBe(true);
 	});
 });
@@ -65,17 +84,153 @@ describe("safeCopyFile", () => {
 		expect(fs.existsSync(`${dest}.bak`)).toBe(false);
 	});
 
-	it("rolls the backup — overwrites a prior .bak with the latest dest", () => {
+	it("returns true and the new content lands when overwriting differing dest", () => {
 		const src = path.join(tmpDir, "new.conf");
 		const dest = path.join(tmpDir, "live.conf");
-		fs.writeFileSync(src, "v3");
-		fs.writeFileSync(dest, "v2");
-		fs.writeFileSync(`${dest}.bak`, "v1-old-stale-backup");
+		fs.writeFileSync(src, "new content");
+		fs.writeFileSync(dest, "previous content");
 
-		safeCopyFile(src, dest);
+		const result = safeCopyFile(src, dest);
 
-		expect(fs.readFileSync(dest, "utf-8")).toBe("v3");
-		expect(fs.readFileSync(`${dest}.bak`, "utf-8")).toBe("v2");
+		expect(result).toBe(true);
+		expect(fs.readFileSync(dest, "utf-8")).toBe("new content");
+	});
+
+	it("returns true when dest does not pre-exist", () => {
+		const src = path.join(tmpDir, "new.conf");
+		const dest = path.join(tmpDir, "fresh.conf");
+		fs.writeFileSync(src, "new content");
+
+		expect(safeCopyFile(src, dest)).toBe(true);
+	});
+
+	it("no-ops (no .bak, returns false) when dest already matches src", () => {
+		const src = path.join(tmpDir, "new.conf");
+		const dest = path.join(tmpDir, "live.conf");
+		fs.writeFileSync(src, "identical content");
+		fs.writeFileSync(dest, "identical content");
+
+		const result = safeCopyFile(src, dest);
+
+		expect(result).toBe(false);
+		expect(fs.readFileSync(dest, "utf-8")).toBe("identical content");
+		expect(fs.existsSync(`${dest}.bak`)).toBe(false);
+	});
+
+	it("a second run preserves the user's ORIGINAL content in .bak", () => {
+		const src = path.join(tmpDir, "new.conf");
+		const dest = path.join(tmpDir, "live.conf");
+		fs.writeFileSync(src, "managed content");
+		fs.writeFileSync(dest, "user original content");
+
+		// First run: backs up the user's original, installs managed content.
+		expect(safeCopyFile(src, dest)).toBe(true);
+		expect(fs.readFileSync(`${dest}.bak`, "utf-8")).toBe(
+			"user original content",
+		);
+
+		// Second run: dest now equals src → must be a no-op and must NOT
+		// clobber the .bak with the previously-synced managed content.
+		expect(safeCopyFile(src, dest)).toBe(false);
+		expect(fs.readFileSync(`${dest}.bak`, "utf-8")).toBe(
+			"user original content",
+		);
+	});
+});
+
+describe("copyDirRecursive symlink handling", () => {
+	let tmpDir;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "haoshoku-copydir-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("recreates file and dir symlinks instead of dereferencing/crashing", () => {
+		const src = path.join(tmpDir, "src");
+		const dest = path.join(tmpDir, "dest");
+
+		// Real file + real dir.
+		fs.mkdirSync(path.join(src, "realdir"), { recursive: true });
+		fs.writeFileSync(path.join(src, "realfile.txt"), "hello");
+		fs.writeFileSync(path.join(src, "realdir", "nested.txt"), "nested");
+
+		// A symlink to the file and a symlink to the dir.
+		fs.symlinkSync("realfile.txt", path.join(src, "filelink"));
+		fs.symlinkSync("realdir", path.join(src, "dirlink"));
+
+		copyDirRecursive(src, dest);
+
+		// Real entries copied as files/dirs.
+		expect(fs.readFileSync(path.join(dest, "realfile.txt"), "utf-8")).toBe(
+			"hello",
+		);
+		expect(
+			fs.readFileSync(path.join(dest, "realdir", "nested.txt"), "utf-8"),
+		).toBe("nested");
+
+		// File symlink recreated as a symlink (not dereferenced).
+		expect(fs.lstatSync(path.join(dest, "filelink")).isSymbolicLink()).toBe(
+			true,
+		);
+		expect(fs.readlinkSync(path.join(dest, "filelink"))).toBe("realfile.txt");
+
+		// Dir symlink recreated as a symlink (would have crashed with EISDIR
+		// under copyFileSync before).
+		expect(fs.lstatSync(path.join(dest, "dirlink")).isSymbolicLink()).toBe(
+			true,
+		);
+		expect(fs.readlinkSync(path.join(dest, "dirlink"))).toBe("realdir");
+	});
+
+	it("replaces an existing destination symlink on a re-run", () => {
+		const src = path.join(tmpDir, "src");
+		const dest = path.join(tmpDir, "dest");
+		fs.mkdirSync(src, { recursive: true });
+		fs.writeFileSync(path.join(src, "target.txt"), "x");
+		fs.symlinkSync("target.txt", path.join(src, "link"));
+
+		copyDirRecursive(src, dest);
+		// Re-run over an already-populated dest must not throw (EEXIST).
+		copyDirRecursive(src, dest);
+
+		expect(fs.readlinkSync(path.join(dest, "link"))).toBe("target.txt");
+	});
+});
+
+describe("promptUser cancellation", () => {
+	it("returns the resolved value for a normal yes answer", async () => {
+		const value = await promptUser("Proceed?", false, {
+			promptFn: async () => ({ value: true }),
+		});
+		expect(value).toBe(true);
+	});
+
+	it("returns the resolved value for a normal no answer", async () => {
+		const value = await promptUser("Proceed?", true, {
+			promptFn: async () => ({ value: false }),
+		});
+		expect(value).toBe(false);
+	});
+
+	it("aborts with exit(130) when the prompt is cancelled (Ctrl+C)", async () => {
+		const exitCalls = [];
+		// Simulate prompts' cancel path: the injected promptFn invokes the
+		// onCancel handler it was given, exactly like the real lib on Ctrl+C.
+		const promptFn = async (_question, opts) => {
+			await opts.onCancel();
+			return {};
+		};
+		await promptUser("Destructive?", false, {
+			promptFn,
+			exit: (code) => {
+				exitCalls.push(code);
+			},
+		});
+		expect(exitCalls).toEqual([130]);
 	});
 });
 


### PR DESCRIPTION
## Summary

Full robustness review of the codebase (multi-agent, every finding adversarially verified), followed by fixes for all 50 confirmed findings — 2 high, 20 medium, 28 low — grouped into 10 file-scoped clusters. Each cluster was implemented test-first and passed spec-compliance + code-quality review; a final cross-cluster integration review approved the whole diff.

## Highlights

**Security / data safety (the 2 HIGH findings)**
- `--zed-backup` sanitizer now recursively strips nested secrets (tokens, api keys, `env` blocks under MCP `context_servers`) before writing to this public repo, and logs every stripped path. Git history audited: no secrets were ever committed.
- `configureGit` no longer clobbers `~/.gitconfig` — backs up first, passes the free-form email as argv (no shell interpolation), skips signing config when keygen fails, and gained its first test suite.

**Systemic fixes (`src/common/utils.js`)**
- Shell-routed commands run under bash with `pipefail` — `curl url | sh` installers (8 sites) no longer report success when the download fails.
- `safeCopyFile` is content-aware: identical re-runs are no-ops, so the user's original `.bak` survives. Every config sync that used to overwrite in place (`~/.claude/settings.json`, Zed, mimeapps, KDE theme, caelestia prefs, `~/.local/bin` scripts) now routes through it.
- Ctrl+C during any prompt aborts (exit 130) instead of meaning "No" and continuing a system-mutating setup.
- `commandExists` uses `Bun.which`; `copyDirRecursive` preserves symlinks.

**OS setup scripts**
- Debian: `ufw enable` is gated on the allow-ssh rule succeeding (remote lockout), sudo preflight, fish PPA only on Ubuntu, `chsh` target from `os.userInfo()`, fail2ban `backend = systemd` for Debian 12+.
- CachyOS: stale `/tmp/paru` removed before clone (re-runs used to fail forever), `base-devel`+`git` install reinstated for makepkg, `installKdeGlass` only claims success when the build succeeded.

**CLI & release integrity**
- Conflicting mode flags error with exit 2 instead of silently running only the first; vanilla Arch (`ID=arch`) is detected; helper failures exit 1 with a clean message; auto-detected bare runs ask for confirmation before mutating the system.
- `release.js` exits 1 on uncaught errors (was exit 0), treats git failure as not-clean, verifies the version regex matched before committing, and is now testable (`import.meta.main`).
- `skill_manager` no longer `rm -rf`s a real user dir at `~/.claude/skills/*` (renames to `.bak`), and resolves the remote default branch instead of hardcoding `origin/main`.

## Test plan

- `bun test`: 333 pass / 0 fail (6 previously untested modules now covered: configure_git, cli_utils, debian_server, release, configure_kde_theme, install_user_scripts)
- `bun run lint`: clean (new `biome.json` honors `.gitignore`)
- CLI smoke: `--help` exits 0; `--zed --audio` errors with exit 2

## Behavioral changes to be aware of

- Bare `haoshoku` now asks one confirmation after OS auto-detection before running the full setup.
- Ctrl+C at any yes/no prompt aborts the program instead of answering "No".