### PR TITLE
fix: support Caelestia 2.1 lockfix

### DIFF
--- a/configs/caelestia-lockfix/LockSurface.qml.portrait-fix.patch
+++ b/configs/caelestia-lockfix/LockSurface.qml.portrait-fix.patch
@@ -12,20 +12,18 @@
      contentItem.Config.screen: screen.name
      contentItem.Tokens.screen: screen.name
  
-@@ -143,13 +148,13 @@
+@@ -143,11 +148,11 @@
                  Anim {
                      target: lockContent
                      property: "implicitWidth"
 -                    to: (root.screen?.height ?? 0) * lockContent.Tokens.sizes.lock.heightMult * lockContent.Tokens.sizes.lock.ratio
 +                    to: root.fitBase * lockContent.Tokens.sizes.lock.heightMult * lockContent.Tokens.sizes.lock.ratio
-                     type: Anim.DefaultSpatial
                  }
                  Anim {
                      target: lockContent
                      property: "implicitHeight"
 -                    to: (root.screen?.height ?? 0) * lockContent.Tokens.sizes.lock.heightMult
 +                    to: root.fitBase * lockContent.Tokens.sizes.lock.heightMult
-                     type: Anim.DefaultSpatial
                  }
              }
 @@ -176,6 +181,8 @@
@@ -41,10 +39,10 @@
              id: content
  
              anchors.centerIn: parent
--            width: (root.screen?.height ?? 0) * Tokens.sizes.lock.heightMult * Tokens.sizes.lock.ratio - Tokens.padding.large * 2
--            height: (root.screen?.height ?? 0) * Tokens.sizes.lock.heightMult - Tokens.padding.large * 2
-+            width: root.fitBase * Tokens.sizes.lock.heightMult * Tokens.sizes.lock.ratio - Tokens.padding.large * 2
-+            height: root.fitBase * Tokens.sizes.lock.heightMult - Tokens.padding.large * 2
+-            width: (root.screen?.height ?? 0) * Tokens.sizes.lock.heightMult * Tokens.sizes.lock.ratio - Tokens.padding.extraLargeIncreased
+-            height: (root.screen?.height ?? 0) * Tokens.sizes.lock.heightMult - Tokens.padding.extraLargeIncreased
++            width: root.fitBase * Tokens.sizes.lock.heightMult * Tokens.sizes.lock.ratio - Tokens.padding.extraLargeIncreased
++            height: root.fitBase * Tokens.sizes.lock.heightMult - Tokens.padding.extraLargeIncreased
  
              lock: root
              opacity: 0

--- a/tests/configure_lockfix.test.js
+++ b/tests/configure_lockfix.test.js
@@ -440,4 +440,17 @@ describe("seeded configs/caelestia-lockfix/ (in-tree static files)", () => {
 		expect(lockSurfacePatch).toContain("lockContent.fitBase");
 		expect(lockSurfacePatch).not.toContain("contentItem.Tokens.sizes.lock");
 	});
+
+	it("targets the Caelestia 2.1 lockscreen layout", () => {
+		const lockSurfacePatch = fs.readFileSync(
+			path.join(CONFIGS_LOCKFIX_DIR, "LockSurface.qml.portrait-fix.patch"),
+			"utf8",
+		);
+
+		expect(lockSurfacePatch).toContain("Tokens.padding.extraLargeIncreased");
+		expect(lockSurfacePatch).not.toContain("Tokens.padding.large * 2");
+		expect(lockSurfacePatch).toContain(
+			"to: root.fitBase * lockContent.Tokens.sizes.lock.heightMult",
+		);
+	});
 });


### PR DESCRIPTION
## What

- Update the portrait lockscreen patch for Caelestia Shell 2.1.
- Add a regression test against the Caelestia 2.1 lockscreen layout.

## Why

Caelestia Shell 2.1 refactored `LockSurface.qml`: the old animation-type context was removed and the lockscreen spacing changed from `Tokens.padding.large * 2` to `Tokens.padding.extraLargeIncreased`. The existing backup patch was therefore no longer applicable after upgrading from 1.6.2.

## Impact

Fresh installs and lockfix reapplication can patch Caelestia 2.1 while preserving the intended portrait-monitor lockscreen layout. This PR changes only the Haoshoku patch and its regression coverage; package upgrades remain machine state.

## Verification

- `bun test`: 399 passed, 0 failed
- `bun run lint`: exit 0; three pre-existing warnings remain in `docs/runbooks/nvidia-video-diagnosis.html`
- `git diff --check`: passed
- Forward patch dry-run against pristine Caelestia 2.1 `.orig` files: passed
- Reverse patch dry-run against the live patched Caelestia 2.1 files: passed
- Live Caelestia 2.1 shell: IPC healthy, 18 layer surfaces across DP-1, DP-2, and HDMI-A-1
